### PR TITLE
Escape colon in job name

### DIFF
--- a/dist/post.js
+++ b/dist/post.js
@@ -24821,7 +24821,10 @@ var formatStep = (step) => {
   }
 };
 var formatName = (name, sec) => {
-  return `${name} (${formatShortElapsedTime(sec)})`;
+  return `${escapeName(name)} (${formatShortElapsedTime(sec)})`;
+};
+var escapeName = (name) => {
+  return name.replaceAll(":", "");
 };
 var convertStepToStatus = (conclusion) => {
   switch (conclusion) {
@@ -24845,7 +24848,7 @@ var createGantt = (workflow, workflowJobs) => {
   const title = workflowJobs[0].workflow_name;
   const jobs = workflowJobs.map((job, jobIndex, _jobs) => {
     var _a;
-    const section = job.name;
+    const section = escapeName(job.name);
     const status = "active";
     const startJobElapsedSec = diffSec(workflow.created_at, job.created_at);
     const waitingRunnerElapsedSec = diffSec(job.created_at, job.started_at);

--- a/src/workflow_gantt.ts
+++ b/src/workflow_gantt.ts
@@ -68,7 +68,11 @@ export const formatStep = (step: ganttStep): string => {
 };
 
 const formatName = (name: string, sec: number): string => {
-  return `${name} (${formatShortElapsedTime(sec)})`;
+  return `${escapeName(name)} (${formatShortElapsedTime(sec)})`;
+};
+
+const escapeName = (name: string): string => {
+  return name.replaceAll(":", "");
 };
 
 const convertStepToStatus = (
@@ -98,7 +102,7 @@ export const createGantt = (
 ): string => {
   const title = workflowJobs[0].workflow_name;
   const jobs = workflowJobs.map((job, jobIndex, _jobs): ganttJob => {
-    const section = job.name;
+    const section = escapeName(job.name);
     const status: ganttStep["status"] = "active";
     const startJobElapsedSec = diffSec(workflow.created_at, job.created_at);
     const waitingRunnerElapsedSec = diffSec(job.created_at, job.started_at);

--- a/tests/workflow_gantt_test.ts
+++ b/tests/workflow_gantt_test.ts
@@ -7,99 +7,100 @@ import {
 } from "../src/workflow_gantt.ts";
 import { Workflow, WorkflowJobs } from "../src/github.ts";
 
-Deno.test("1 section gantt", () => {
-  const workflow = {
-    "id": 5977929222,
-    "name": "POC",
-    "run_number": 5,
-    "event": "push",
-    "status": "completed",
-    "conclusion": "success",
-    "workflow_id": 66989622,
-    "created_at": "2023-08-25T15:57:51Z",
-    "updated_at": "2023-08-25T15:58:19Z",
-  } as unknown as Workflow;
+Deno.test("1 section gantt", async (t) => {
+  await t.step("all steps are success", () => {
+    const workflow = {
+      "id": 5977929222,
+      "name": "POC",
+      "run_number": 5,
+      "event": "push",
+      "status": "completed",
+      "conclusion": "success",
+      "workflow_id": 66989622,
+      "created_at": "2023-08-25T15:57:51Z",
+      "updated_at": "2023-08-25T15:58:19Z",
+    } as unknown as Workflow;
 
-  const workflowJobs = [{
-    "id": 16218974194,
-    "run_id": 5977929222,
-    "workflow_name": "POC",
-    "status": "completed",
-    "conclusion": "success",
-    "created_at": "2023-08-25T15:57:52Z",
-    "started_at": "2023-08-25T15:57:59Z",
-    "completed_at": "2023-08-25T15:58:17Z",
-    "name": "run_self",
-    "steps": [
-      {
-        "name": "Set up job",
-        "status": "completed",
-        "conclusion": "success",
-        "number": 1,
-        "started_at": "2023-08-26T00:57:58.000+09:00",
-        "completed_at": "2023-08-26T00:58:00.000+09:00",
-      },
-      {
-        "name": "Run actions/checkout@v3",
-        "status": "completed",
-        "conclusion": "success",
-        "number": 2,
-        "started_at": "2023-08-26T00:58:00.000+09:00",
-        "completed_at": "2023-08-26T00:58:01.000+09:00",
-      },
-      {
-        "name": "Run denoland/setup-deno@v1",
-        "status": "completed",
-        "conclusion": "success",
-        "number": 3,
-        "started_at": "2023-08-26T00:58:02.000+09:00",
-        "completed_at": "2023-08-26T00:58:03.000+09:00",
-      },
-      {
-        "name": "Run deno task bundle",
-        "status": "completed",
-        "conclusion": "success",
-        "number": 4,
-        "started_at": "2023-08-26T00:58:04.000+09:00",
-        "completed_at": "2023-08-26T00:58:15.000+09:00",
-      },
-      {
-        "name": "Run self action",
-        "status": "completed",
-        "conclusion": "success",
-        "number": 5,
-        "started_at": "2023-08-26T00:58:15.000+09:00",
-        "completed_at": "2023-08-26T00:58:15.000+09:00",
-      },
-      {
-        "name": "Post Run self action",
-        "status": "completed",
-        "conclusion": "success",
-        "number": 9,
-        "started_at": "2023-08-26T00:58:15.000+09:00",
-        "completed_at": "2023-08-26T00:58:15.000+09:00",
-      },
-      {
-        "name": "Post Run actions/checkout@v3",
-        "status": "completed",
-        "conclusion": "success",
-        "number": 10,
-        "started_at": "2023-08-26T00:58:15.000+09:00",
-        "completed_at": "2023-08-26T00:58:15.000+09:00",
-      },
-      {
-        "name": "Complete job",
-        "status": "completed",
-        "conclusion": "success",
-        "number": 11,
-        "started_at": "2023-08-26T00:58:15.000+09:00",
-        "completed_at": "2023-08-26T00:58:15.000+09:00",
-      },
-    ],
-  }] as unknown as WorkflowJobs;
+    const workflowJobs = [{
+      "id": 16218974194,
+      "run_id": 5977929222,
+      "workflow_name": "POC",
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2023-08-25T15:57:52Z",
+      "started_at": "2023-08-25T15:57:59Z",
+      "completed_at": "2023-08-25T15:58:17Z",
+      "name": "run_self",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 1,
+          "started_at": "2023-08-26T00:57:58.000+09:00",
+          "completed_at": "2023-08-26T00:58:00.000+09:00",
+        },
+        {
+          "name": "Run actions/checkout@v3",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 2,
+          "started_at": "2023-08-26T00:58:00.000+09:00",
+          "completed_at": "2023-08-26T00:58:01.000+09:00",
+        },
+        {
+          "name": "Run denoland/setup-deno@v1",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 3,
+          "started_at": "2023-08-26T00:58:02.000+09:00",
+          "completed_at": "2023-08-26T00:58:03.000+09:00",
+        },
+        {
+          "name": "Run deno task bundle",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 4,
+          "started_at": "2023-08-26T00:58:04.000+09:00",
+          "completed_at": "2023-08-26T00:58:15.000+09:00",
+        },
+        {
+          "name": "Run self action",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 5,
+          "started_at": "2023-08-26T00:58:15.000+09:00",
+          "completed_at": "2023-08-26T00:58:15.000+09:00",
+        },
+        {
+          "name": "Post Run self action",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 9,
+          "started_at": "2023-08-26T00:58:15.000+09:00",
+          "completed_at": "2023-08-26T00:58:15.000+09:00",
+        },
+        {
+          "name": "Post Run actions/checkout@v3",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 10,
+          "started_at": "2023-08-26T00:58:15.000+09:00",
+          "completed_at": "2023-08-26T00:58:15.000+09:00",
+        },
+        {
+          "name": "Complete job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 11,
+          "started_at": "2023-08-26T00:58:15.000+09:00",
+          "completed_at": "2023-08-26T00:58:15.000+09:00",
+        },
+      ],
+    }] as unknown as WorkflowJobs;
 
-  // deno-fmt-ignore
-  const expect = `
+    // deno-fmt-ignore
+    const expect = `
 \`\`\`mermaid
 gantt
 title ${workflowJobs[0].workflow_name}
@@ -118,70 +119,70 @@ ${workflowJobs[0].steps![7].name} (0s) :job0-8, after job0-7, 0s
 \`\`\`
 `;
 
-  assertEquals(createGantt(workflow, workflowJobs), expect);
-});
+    assertEquals(createGantt(workflow, workflowJobs), expect);
+  });
 
-Deno.test("1 section gantt with skipped and failure steps", () => {
-  const workflow = {
-    "id": 5977929222,
-    "name": "POC",
-    "run_number": 5,
-    "event": "push",
-    "status": "completed",
-    "conclusion": "failure",
-    "workflow_id": 66989622,
-    "created_at": "2023-08-25T15:57:51Z",
-    "updated_at": "2023-08-25T15:58:19Z",
-  } as unknown as Workflow;
+  await t.step("job has skipped and failure steps", () => {
+    const workflow = {
+      "id": 5977929222,
+      "name": "POC",
+      "run_number": 5,
+      "event": "push",
+      "status": "completed",
+      "conclusion": "failure",
+      "workflow_id": 66989622,
+      "created_at": "2023-08-25T15:57:51Z",
+      "updated_at": "2023-08-25T15:58:19Z",
+    } as unknown as Workflow;
 
-  const workflowJobs = [{
-    "id": 16218974194,
-    "run_id": 5977929222,
-    "workflow_name": "POC",
-    "status": "completed",
-    "conclusion": "failure",
-    "created_at": "2023-08-25T15:57:52Z",
-    "started_at": "2023-08-25T15:57:59Z",
-    "completed_at": "2023-08-25T15:58:17Z",
-    "name": "run_self",
-    "steps": [
-      {
-        "name": "Set up job",
-        "status": "completed",
-        "conclusion": "skipped",
-        "number": 1,
-        "started_at": "2023-08-26T00:57:58.000+09:00",
-        "completed_at": "2023-08-26T00:58:00.000+09:00",
-      },
-      {
-        "name": "Run actions/checkout@v3",
-        "status": "completed",
-        "conclusion": "failure",
-        "number": 2,
-        "started_at": "2023-08-26T00:58:00.000+09:00",
-        "completed_at": "2023-08-26T00:58:01.000+09:00",
-      },
-      {
-        "name": "Post Run actions/checkout@v3",
-        "status": "completed",
-        "conclusion": "success",
-        "number": 10,
-        "started_at": "2023-08-26T00:58:15.000+09:00",
-        "completed_at": "2023-08-26T00:58:15.000+09:00",
-      },
-      {
-        "name": "Complete job",
-        "status": "completed",
-        "conclusion": "success",
-        "number": 11,
-        "started_at": "2023-08-26T00:58:15.000+09:00",
-        "completed_at": "2023-08-26T00:58:15.000+09:00",
-      },
-    ],
-  }] as unknown as WorkflowJobs;
+    const workflowJobs = [{
+      "id": 16218974194,
+      "run_id": 5977929222,
+      "workflow_name": "POC",
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2023-08-25T15:57:52Z",
+      "started_at": "2023-08-25T15:57:59Z",
+      "completed_at": "2023-08-25T15:58:17Z",
+      "name": "run_self",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 1,
+          "started_at": "2023-08-26T00:57:58.000+09:00",
+          "completed_at": "2023-08-26T00:58:00.000+09:00",
+        },
+        {
+          "name": "Run actions/checkout@v3",
+          "status": "completed",
+          "conclusion": "failure",
+          "number": 2,
+          "started_at": "2023-08-26T00:58:00.000+09:00",
+          "completed_at": "2023-08-26T00:58:01.000+09:00",
+        },
+        {
+          "name": "Post Run actions/checkout@v3",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 10,
+          "started_at": "2023-08-26T00:58:15.000+09:00",
+          "completed_at": "2023-08-26T00:58:15.000+09:00",
+        },
+        {
+          "name": "Complete job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 11,
+          "started_at": "2023-08-26T00:58:15.000+09:00",
+          "completed_at": "2023-08-26T00:58:15.000+09:00",
+        },
+      ],
+    }] as unknown as WorkflowJobs;
 
-  // deno-fmt-ignore
-  const expect = `
+    // deno-fmt-ignore
+    const expect = `
 \`\`\`mermaid
 gantt
 title ${workflowJobs[0].workflow_name}
@@ -196,173 +197,243 @@ ${workflowJobs[0].steps![3].name} (0s) :job0-4, after job0-3, 0s
 \`\`\`
 `;
 
-  assertEquals(createGantt(workflow, workflowJobs), expect);
+    assertEquals(createGantt(workflow, workflowJobs), expect);
+  });
+
+  await t.step("job has status:in_progress and status:queued steps", () => {
+    const workflow = {
+      "id": 6290960492,
+      "name": "CI",
+      "run_number": 53,
+      "event": "pull_request",
+      "status": "in_progress",
+      "conclusion": null,
+      "created_at": "2023-09-24T15:41:23Z",
+      "updated_at": "2023-09-24T15:46:01Z",
+    } as unknown as Workflow;
+
+    const workflowJobs = [{
+      "id": 17078901763,
+      "run_id": 6290960492,
+      "workflow_name": "CI",
+      "status": "in_progress",
+      "conclusion": null,
+      "created_at": "2023-09-24T15:45:54Z",
+      "started_at": "2023-09-24T15:46:00Z",
+      "completed_at": null,
+      "name": "run_self",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 1,
+          "started_at": "2023-09-24T15:46:00.000Z",
+          "completed_at": "2023-09-24T15:46:01.000Z",
+        },
+        {
+          "name": "Download bundled dist",
+          "status": "in_progress",
+          "conclusion": null,
+          "number": 2,
+          "started_at": "2023-09-24T15:46:01.000Z",
+          "completed_at": null,
+        },
+        {
+          "name": "Run self action",
+          "status": "queued",
+          "conclusion": null,
+          "number": 3,
+          "started_at": null,
+          "completed_at": null,
+        },
+      ],
+    }] as unknown as WorkflowJobs;
+
+    // deno-fmt-ignore
+    const expect = `
+\`\`\`mermaid
+gantt
+title ${workflowJobs[0].workflow_name}
+dateFormat  HH:mm:ss
+axisFormat  %H:%M:%S
+section ${workflowJobs[0].name}
+Waiting for a runner (6s) :active, job0-0, 00:04:31, 6s
+${workflowJobs[0].steps![0].name} (1s) :job0-1, after job0-0, 1s
+${workflowJobs[0].steps![1].name} (0s) :active, job0-2, after job0-1, 0s
+${workflowJobs[0].steps![2].name} (0s) :active, job0-3, after job0-2, 0s
+\`\`\`
+`;
+
+    assertEquals(createGantt(workflow, workflowJobs), expect);
+  });
 });
 
-Deno.test("2 section gantt", () => {
-  const workflow = {
-    "id": 5833450919,
-    "name": "Check self-hosted runner",
-    "run_number": 128,
-    "event": "workflow_dispatch",
-    "status": "completed",
-    "conclusion": "success",
-    "workflow_id": 10970418,
-    "created_at": "2023-08-11T14:00:48Z",
-    "updated_at": "2023-08-11T14:01:56Z",
-  } as unknown as Workflow;
-
-  const workflowJobs = [
-    {
-      "id": 15820938470,
-      "run_id": 5833450919,
-      "workflow_name": "Check self-hosted runner",
+Deno.test("2 section gantt", async (t) => {
+  await t.step("all steps are success", () => {
+    const workflow = {
+      "id": 5833450919,
+      "name": "Check self-hosted runner",
+      "run_number": 128,
+      "event": "workflow_dispatch",
       "status": "completed",
       "conclusion": "success",
-      "created_at": "2023-08-11T14:00:50Z",
-      "started_at": "2023-08-11T14:01:31Z",
-      "completed_at": "2023-08-11T14:01:36Z",
-      "name": "node",
-      "steps": [
-        {
-          "name": "Set up job",
-          "status": "completed",
-          "conclusion": "success",
-          "number": 1,
-          "started_at": "2023-08-11T23:01:30.000+09:00",
-          "completed_at": "2023-08-11T23:01:32.000+09:00",
-        },
-        {
-          "name": "Set up runner",
-          "status": "completed",
-          "conclusion": "success",
-          "number": 2,
-          "started_at": "2023-08-11T23:01:32.000+09:00",
-          "completed_at": "2023-08-11T23:01:32.000+09:00",
-        },
-        {
-          "name": "Run actions/checkout@v3",
-          "status": "completed",
-          "conclusion": "success",
-          "number": 3,
-          "started_at": "2023-08-11T23:01:34.000+09:00",
-          "completed_at": "2023-08-11T23:01:34.000+09:00",
-        },
-        {
-          "name": "Run actions/setup-node@v3",
-          "status": "completed",
-          "conclusion": "success",
-          "number": 4,
-          "started_at": "2023-08-11T23:01:35.000+09:00",
-          "completed_at": "2023-08-11T23:01:35.000+09:00",
-        },
-        {
-          "name": "Post Run actions/setup-node@v3",
-          "status": "completed",
-          "conclusion": "success",
-          "number": 6,
-          "started_at": "2023-08-11T23:01:35.000+09:00",
-          "completed_at": "2023-08-11T23:01:35.000+09:00",
-        },
-        {
-          "name": "Post Run actions/checkout@v3",
-          "status": "completed",
-          "conclusion": "success",
-          "number": 7,
-          "started_at": "2023-08-11T23:01:35.000+09:00",
-          "completed_at": "2023-08-11T23:01:35.000+09:00",
-        },
-        {
-          "name": "Complete runner",
-          "status": "completed",
-          "conclusion": "success",
-          "number": 8,
-          "started_at": "2023-08-11T23:01:36.000+09:00",
-          "completed_at": "2023-08-11T23:01:36.000+09:00",
-        },
-        {
-          "name": "Complete job",
-          "status": "completed",
-          "conclusion": "success",
-          "number": 9,
-          "started_at": "2023-08-11T23:01:35.000+09:00",
-          "completed_at": "2023-08-11T23:01:35.000+09:00",
-        },
-      ],
-    },
-    {
-      "id": 15820938790,
-      "run_id": 5833450919,
-      "workflow_name": "Check self-hosted runner",
-      "status": "completed",
-      "conclusion": "success",
-      "created_at": "2023-08-11T14:00:51Z",
-      "started_at": "2023-08-11T14:01:30Z",
-      "completed_at": "2023-08-11T14:01:50Z",
-      "name": "go",
-      "steps": [
-        {
-          "name": "Set up job",
-          "status": "completed",
-          "conclusion": "success",
-          "number": 1,
-          "started_at": "2023-08-11T23:01:29.000+09:00",
-          "completed_at": "2023-08-11T23:01:32.000+09:00",
-        },
-        {
-          "name": "Set up runner",
-          "status": "completed",
-          "conclusion": "success",
-          "number": 2,
-          "started_at": "2023-08-11T23:01:32.000+09:00",
-          "completed_at": "2023-08-11T23:01:32.000+09:00",
-        },
-        {
-          "name": "Run actions/setup-go@v4",
-          "status": "completed",
-          "conclusion": "success",
-          "number": 3,
-          "started_at": "2023-08-11T23:01:33.000+09:00",
-          "completed_at": "2023-08-11T23:01:49.000+09:00",
-        },
-        {
-          "name": "Run go version",
-          "status": "completed",
-          "conclusion": "success",
-          "number": 4,
-          "started_at": "2023-08-11T23:01:49.000+09:00",
-          "completed_at": "2023-08-11T23:01:49.000+09:00",
-        },
-        {
-          "name": "Post Run actions/setup-go@v4",
-          "status": "completed",
-          "conclusion": "success",
-          "number": 7,
-          "started_at": "2023-08-11T23:01:49.000+09:00",
-          "completed_at": "2023-08-11T23:01:49.000+09:00",
-        },
-        {
-          "name": "Complete runner",
-          "status": "completed",
-          "conclusion": "success",
-          "number": 8,
-          "started_at": "2023-08-11T23:01:50.000+09:00",
-          "completed_at": "2023-08-11T23:01:50.000+09:00",
-        },
-        {
-          "name": "Complete job",
-          "status": "completed",
-          "conclusion": "success",
-          "number": 9,
-          "started_at": "2023-08-11T23:01:49.000+09:00",
-          "completed_at": "2023-08-11T23:01:49.000+09:00",
-        },
-      ],
-    },
-  ] as unknown as WorkflowJobs;
+      "workflow_id": 10970418,
+      "created_at": "2023-08-11T14:00:48Z",
+      "updated_at": "2023-08-11T14:01:56Z",
+    } as unknown as Workflow;
 
-  // deno-fmt-ignore
-  const expect = `
+    const workflowJobs = [
+      {
+        "id": 15820938470,
+        "run_id": 5833450919,
+        "workflow_name": "Check self-hosted runner",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2023-08-11T14:00:50Z",
+        "started_at": "2023-08-11T14:01:31Z",
+        "completed_at": "2023-08-11T14:01:36Z",
+        "name": "node",
+        "steps": [
+          {
+            "name": "Set up job",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 1,
+            "started_at": "2023-08-11T23:01:30.000+09:00",
+            "completed_at": "2023-08-11T23:01:32.000+09:00",
+          },
+          {
+            "name": "Set up runner",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 2,
+            "started_at": "2023-08-11T23:01:32.000+09:00",
+            "completed_at": "2023-08-11T23:01:32.000+09:00",
+          },
+          {
+            "name": "Run actions/checkout@v3",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 3,
+            "started_at": "2023-08-11T23:01:34.000+09:00",
+            "completed_at": "2023-08-11T23:01:34.000+09:00",
+          },
+          {
+            "name": "Run actions/setup-node@v3",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 4,
+            "started_at": "2023-08-11T23:01:35.000+09:00",
+            "completed_at": "2023-08-11T23:01:35.000+09:00",
+          },
+          {
+            "name": "Post Run actions/setup-node@v3",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 6,
+            "started_at": "2023-08-11T23:01:35.000+09:00",
+            "completed_at": "2023-08-11T23:01:35.000+09:00",
+          },
+          {
+            "name": "Post Run actions/checkout@v3",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 7,
+            "started_at": "2023-08-11T23:01:35.000+09:00",
+            "completed_at": "2023-08-11T23:01:35.000+09:00",
+          },
+          {
+            "name": "Complete runner",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 8,
+            "started_at": "2023-08-11T23:01:36.000+09:00",
+            "completed_at": "2023-08-11T23:01:36.000+09:00",
+          },
+          {
+            "name": "Complete job",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 9,
+            "started_at": "2023-08-11T23:01:35.000+09:00",
+            "completed_at": "2023-08-11T23:01:35.000+09:00",
+          },
+        ],
+      },
+      {
+        "id": 15820938790,
+        "run_id": 5833450919,
+        "workflow_name": "Check self-hosted runner",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2023-08-11T14:00:51Z",
+        "started_at": "2023-08-11T14:01:30Z",
+        "completed_at": "2023-08-11T14:01:50Z",
+        "name": "go",
+        "steps": [
+          {
+            "name": "Set up job",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 1,
+            "started_at": "2023-08-11T23:01:29.000+09:00",
+            "completed_at": "2023-08-11T23:01:32.000+09:00",
+          },
+          {
+            "name": "Set up runner",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 2,
+            "started_at": "2023-08-11T23:01:32.000+09:00",
+            "completed_at": "2023-08-11T23:01:32.000+09:00",
+          },
+          {
+            "name": "Run actions/setup-go@v4",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 3,
+            "started_at": "2023-08-11T23:01:33.000+09:00",
+            "completed_at": "2023-08-11T23:01:49.000+09:00",
+          },
+          {
+            "name": "Run go version",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 4,
+            "started_at": "2023-08-11T23:01:49.000+09:00",
+            "completed_at": "2023-08-11T23:01:49.000+09:00",
+          },
+          {
+            "name": "Post Run actions/setup-go@v4",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 7,
+            "started_at": "2023-08-11T23:01:49.000+09:00",
+            "completed_at": "2023-08-11T23:01:49.000+09:00",
+          },
+          {
+            "name": "Complete runner",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 8,
+            "started_at": "2023-08-11T23:01:50.000+09:00",
+            "completed_at": "2023-08-11T23:01:50.000+09:00",
+          },
+          {
+            "name": "Complete job",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 9,
+            "started_at": "2023-08-11T23:01:49.000+09:00",
+            "completed_at": "2023-08-11T23:01:49.000+09:00",
+          },
+        ],
+      },
+    ] as unknown as WorkflowJobs;
+
+    // deno-fmt-ignore
+    const expect = `
 \`\`\`mermaid
 gantt
 title ${workflowJobs[0].workflow_name}
@@ -390,75 +461,8 @@ ${workflowJobs[1].steps![6].name} (0s) :job1-7, after job1-6, 0s
 \`\`\`
 `;
 
-  assertEquals(createGantt(workflow, workflowJobs), expect);
-});
-
-Deno.test("1 section gantt includes status:in_progress and status:queued steps", () => {
-  const workflow = {
-    "id": 6290960492,
-    "name": "CI",
-    "run_number": 53,
-    "event": "pull_request",
-    "status": "in_progress",
-    "conclusion": null,
-    "created_at": "2023-09-24T15:41:23Z",
-    "updated_at": "2023-09-24T15:46:01Z",
-  } as unknown as Workflow;
-
-  const workflowJobs = [{
-    "id": 17078901763,
-    "run_id": 6290960492,
-    "workflow_name": "CI",
-    "status": "in_progress",
-    "conclusion": null,
-    "created_at": "2023-09-24T15:45:54Z",
-    "started_at": "2023-09-24T15:46:00Z",
-    "completed_at": null,
-    "name": "run_self",
-    "steps": [
-      {
-        "name": "Set up job",
-        "status": "completed",
-        "conclusion": "success",
-        "number": 1,
-        "started_at": "2023-09-24T15:46:00.000Z",
-        "completed_at": "2023-09-24T15:46:01.000Z",
-      },
-      {
-        "name": "Download bundled dist",
-        "status": "in_progress",
-        "conclusion": null,
-        "number": 2,
-        "started_at": "2023-09-24T15:46:01.000Z",
-        "completed_at": null,
-      },
-      {
-        "name": "Run self action",
-        "status": "queued",
-        "conclusion": null,
-        "number": 3,
-        "started_at": null,
-        "completed_at": null,
-      },
-    ],
-  }] as unknown as WorkflowJobs;
-
-  // deno-fmt-ignore
-  const expect = `
-\`\`\`mermaid
-gantt
-title ${workflowJobs[0].workflow_name}
-dateFormat  HH:mm:ss
-axisFormat  %H:%M:%S
-section ${workflowJobs[0].name}
-Waiting for a runner (6s) :active, job0-0, 00:04:31, 6s
-${workflowJobs[0].steps![0].name} (1s) :job0-1, after job0-0, 1s
-${workflowJobs[0].steps![1].name} (0s) :active, job0-2, after job0-1, 0s
-${workflowJobs[0].steps![2].name} (0s) :active, job0-3, after job0-2, 0s
-\`\`\`
-`;
-
-  assertEquals(createGantt(workflow, workflowJobs), expect);
+    assertEquals(createGantt(workflow, workflowJobs), expect);
+  });
 });
 
 Deno.test("formatStep", async (t) => {

--- a/tests/workflow_gantt_test.ts
+++ b/tests/workflow_gantt_test.ts
@@ -267,6 +267,80 @@ ${workflowJobs[0].steps![2].name} (0s) :active, job0-3, after job0-2, 0s
 
     assertEquals(createGantt(workflow, workflowJobs), expect);
   });
+
+  await t.step(
+    "colon in job name or step name is deleted",
+    () => {
+      const workflow = {
+        "id": 6301810753,
+        "name": "CI",
+        "run_number": 60,
+        "event": "pull_request",
+        "status": "in_progress",
+        "conclusion": null,
+        "workflow_id": 69674074,
+        "created_at": "2023-09-25T15:55:47Z",
+        "updated_at": "2023-09-25T15:57:36Z",
+      } as unknown as Workflow;
+
+      const workflowJobs = [{
+        "id": 17107722147,
+        "run_id": 6301810753,
+        "workflow_name": "CI",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2023-09-25T15:55:50Z",
+        "started_at": "2023-09-25T15:55:56Z",
+        "completed_at": "2023-09-25T15:56:06Z",
+        "name": "check: deno 1.36.1",
+        "steps": [
+          {
+            "name": "Set up job",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 1,
+            "started_at": "2023-09-25T15:55:56.000Z",
+            "completed_at": "2023-09-25T15:55:57.000Z",
+          },
+          {
+            "name": "check: deno",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 2,
+            "started_at": "2023-09-25T15:55:57.000Z",
+            "completed_at": "2023-09-25T15:55:58.000Z",
+          },
+          {
+            "name": "Complete job",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 3,
+            "started_at": "2023-09-25T15:56:03.000Z",
+            "completed_at": "2023-09-25T15:56:03.000Z",
+          },
+        ],
+      }] as unknown as WorkflowJobs;
+
+      const expectJobName = "check deno 1.36.1";
+      const expectStepName = "check deno";
+      // deno-fmt-ignore
+      const expect = `
+\`\`\`mermaid
+gantt
+title ${workflowJobs[0].workflow_name}
+dateFormat  HH:mm:ss
+axisFormat  %H:%M:%S
+section ${expectJobName}
+Waiting for a runner (6s) :active, job0-0, 00:00:03, 6s
+${workflowJobs[0].steps![0].name} (1s) :job0-1, after job0-0, 1s
+${expectStepName} (1s) :job0-2, after job0-1, 1s
+${workflowJobs[0].steps![2].name} (0s) :job0-3, after job0-2, 0s
+\`\`\`
+`;
+
+      assertEquals(createGantt(workflow, workflowJobs), expect);
+    },
+  );
 });
 
 Deno.test("2 section gantt", async (t) => {


### PR DESCRIPTION
Mermaid gantt rely on ":" character, so mermaid syntax will broken if job name or step name has ":".
We should escape ":" by removing them.