### PR TITLE
Bugfix mermaid diagram title is 'undefined' on GHES

### DIFF
--- a/dist/post.js
+++ b/dist/post.js
@@ -24852,7 +24852,7 @@ var filterJobs = (jobs) => {
   return jobs.filter((job) => job.conclusion !== "skipped");
 };
 var createGantt = (workflow, workflowJobs) => {
-  const title = workflowJobs[0].workflow_name;
+  const title = workflow.name;
   const jobs = filterJobs(workflowJobs).map(
     (job, jobIndex, _jobs) => {
       const section = escapeName(job.name);

--- a/src/workflow_gantt.ts
+++ b/src/workflow_gantt.ts
@@ -112,7 +112,7 @@ export const createGantt = (
   workflow: Workflow,
   workflowJobs: WorkflowJobs,
 ): string => {
-  const title = workflowJobs[0].workflow_name;
+  const title = workflow.name;
   const jobs = filterJobs(workflowJobs).map(
     (job, jobIndex, _jobs): ganttJob => {
       const section = escapeName(job.name);


### PR DESCRIPTION
At least GHES v3.8 occurs this bug.
To fix it, we get mermaid gantt chart name from `workflow_run` API result.