### PR TITLE
Bugfix start time on gantt diagram is invalid when job is retried

### DIFF
--- a/dist/post.js
+++ b/dist/post.js
@@ -24783,6 +24783,7 @@ var require_dist_node20 = __commonJS({
 
 // npm/src/post.ts
 var import_promises = require("timers/promises");
+var import_process2 = __toESM(require("process"));
 var import_core = __toESM(require_core());
 var github = __toESM(require_github());
 
@@ -24910,19 +24911,21 @@ var createOctokit = (token) => {
     baseUrl
   });
 };
-var fetchWorkflow = async (octokit, owner, repo, runId) => {
-  const workflow = await octokit.rest.actions.getWorkflowRun({
+var fetchWorkflow = async (octokit, owner, repo, runId, runAttempt) => {
+  const workflow = await octokit.rest.actions.getWorkflowRunAttempt({
     owner,
     repo,
-    run_id: runId
+    run_id: runId,
+    attempt_number: runAttempt
   });
   return workflow.data;
 };
-var fetchWorkflowRunJobs = async (octokit, owner, repo, runId) => {
-  const workflowJob = await octokit.rest.actions.listJobsForWorkflowRun({
+var fetchWorkflowRunJobs = async (octokit, owner, repo, runId, runAttempt) => {
+  const workflowJob = await octokit.rest.actions.listJobsForWorkflowRunAttempt({
     owner,
     repo,
-    run_id: runId
+    run_id: runId,
+    attempt_number: runAttempt
   });
   return workflowJob.data.jobs;
 };
@@ -24934,11 +24937,13 @@ var main = async () => {
   (0, import_core.info)("Wait for workflow API result stability...");
   await (0, import_promises.setTimeout)(1e3);
   (0, import_core.info)("Fetch workflow...");
+  const runAttempt = import_process2.default.env.GITHUB_RUN_ATTEMPT ? Number(import_process2.default.env.GITHUB_RUN_ATTEMPT) : 1;
   const workflow = await fetchWorkflow(
     octokit,
     github.context.repo.owner,
     github.context.repo.repo,
-    github.context.runId
+    github.context.runId,
+    runAttempt
   );
   (0, import_core.debug)(JSON.stringify(workflow, null, 2));
   (0, import_core.info)("Fetch workflow_job...");
@@ -24946,7 +24951,8 @@ var main = async () => {
     octokit,
     github.context.repo.owner,
     github.context.repo.repo,
-    github.context.runId
+    github.context.runId,
+    runAttempt
   );
   (0, import_core.debug)(JSON.stringify(workflowJobs, null, 2));
   (0, import_core.info)("Create gantt mermaid diagram...");

--- a/dist/post.js
+++ b/dist/post.js
@@ -24857,7 +24857,10 @@ var createGantt = (workflow, workflowJobs) => {
     (job, jobIndex, _jobs) => {
       const section = escapeName(job.name);
       const status = "active";
-      const startJobElapsedSec = diffSec(workflow.created_at, job.created_at);
+      const startJobElapsedSec = diffSec(
+        workflow.run_started_at,
+        job.created_at
+      );
       const waitingRunnerElapsedSec = diffSec(job.created_at, job.started_at);
       const waitingRunnerStep = {
         name: formatName("Waiting for a runner", waitingRunnerElapsedSec),

--- a/src/github.ts
+++ b/src/github.ts
@@ -4,9 +4,13 @@ import { Octokit, RestEndpointMethodTypes } from "npm:@octokit/rest@19.0.13";
 import process from "node:process";
 
 export type Workflow =
-  RestEndpointMethodTypes["actions"]["getWorkflowRun"]["response"]["data"];
+  RestEndpointMethodTypes["actions"]["getWorkflowRunAttempt"]["response"][
+    "data"
+  ];
 export type WorkflowJobs =
-  RestEndpointMethodTypes["actions"]["listJobsForWorkflowRun"]["response"][
+  RestEndpointMethodTypes["actions"]["listJobsForWorkflowRunAttempt"][
+    "response"
+  ][
     "data"
   ]["jobs"];
 
@@ -23,11 +27,13 @@ export const fetchWorkflow = async (
   owner: string,
   repo: string,
   runId: number,
+  runAttempt: number,
 ): Promise<Workflow> => {
-  const workflow = await octokit.rest.actions.getWorkflowRun({
+  const workflow = await octokit.rest.actions.getWorkflowRunAttempt({
     owner,
     repo,
     run_id: runId,
+    attempt_number: runAttempt,
   });
   return workflow.data;
 };
@@ -37,11 +43,13 @@ export const fetchWorkflowRunJobs = async (
   owner: string,
   repo: string,
   runId: number,
+  runAttempt: number,
 ): Promise<WorkflowJobs> => {
-  const workflowJob = await octokit.rest.actions.listJobsForWorkflowRun({
+  const workflowJob = await octokit.rest.actions.listJobsForWorkflowRunAttempt({
     owner,
     repo,
     run_id: runId,
+    attempt_number: runAttempt,
   });
   return workflowJob.data.jobs;
 };

--- a/src/post.ts
+++ b/src/post.ts
@@ -1,4 +1,5 @@
 import { setTimeout } from "node:timers/promises";
+import process from "node:process";
 import { debug, getInput, info, summary } from "npm:@actions/core@1.10.0";
 import * as github from "npm:@actions/github@5.1.1";
 import { createGantt } from "./workflow_gantt.ts";
@@ -16,11 +17,17 @@ const main = async () => {
   await setTimeout(1000);
 
   info("Fetch workflow...");
+  // Currently, @actions/core does not provide runAttempt.
+  // ref: https://github.com/actions/toolkit/pull/1387
+  const runAttempt = process.env.GITHUB_RUN_ATTEMPT
+    ? Number(process.env.GITHUB_RUN_ATTEMPT)
+    : 1;
   const workflow = await fetchWorkflow(
     octokit,
     github.context.repo.owner,
     github.context.repo.repo,
     github.context.runId,
+    runAttempt,
   );
   debug(JSON.stringify(workflow, null, 2));
   info("Fetch workflow_job...");
@@ -29,6 +36,7 @@ const main = async () => {
     github.context.repo.owner,
     github.context.repo.repo,
     github.context.runId,
+    runAttempt,
   );
   debug(JSON.stringify(workflowJobs, null, 2));
 

--- a/src/workflow_gantt.ts
+++ b/src/workflow_gantt.ts
@@ -117,7 +117,10 @@ export const createGantt = (
     (job, jobIndex, _jobs): ganttJob => {
       const section = escapeName(job.name);
       const status: ganttStep["status"] = "active";
-      const startJobElapsedSec = diffSec(workflow.created_at, job.created_at);
+      const startJobElapsedSec = diffSec(
+        workflow.run_started_at,
+        job.created_at,
+      );
       const waitingRunnerElapsedSec = diffSec(job.created_at, job.started_at);
       const waitingRunnerStep: ganttStep = {
         name: formatName("Waiting for a runner", waitingRunnerElapsedSec),

--- a/tests/workflow_gantt_test.ts
+++ b/tests/workflow_gantt_test.ts
@@ -19,6 +19,7 @@ Deno.test("1 section gantt", async (t) => {
       "workflow_id": 66989622,
       "created_at": "2023-08-25T15:57:51Z",
       "updated_at": "2023-08-25T15:58:19Z",
+      "run_started_at": "2023-08-25T15:57:51Z",
     } as unknown as Workflow;
 
     const workflowJobs = [{
@@ -133,6 +134,7 @@ ${workflowJobs[0].steps![7].name} (0s) :job0-8, after job0-7, 0s
       "workflow_id": 66989622,
       "created_at": "2023-08-25T15:57:51Z",
       "updated_at": "2023-08-25T15:58:19Z",
+      "run_started_at": "2023-08-25T15:57:51Z",
     } as unknown as Workflow;
 
     const workflowJobs = [{
@@ -210,6 +212,7 @@ ${workflowJobs[0].steps![3].name} (0s) :job0-4, after job0-3, 0s
       "conclusion": null,
       "created_at": "2023-09-24T15:41:23Z",
       "updated_at": "2023-09-24T15:46:01Z",
+      "run_started_at": "2023-09-24T15:41:23Z",
     } as unknown as Workflow;
 
     const workflowJobs = [{
@@ -279,6 +282,7 @@ ${workflowJobs[0].steps![0].name} (1s) :job0-1, after job0-0, 1s
         "workflow_id": 69674074,
         "created_at": "2023-09-25T15:55:47Z",
         "updated_at": "2023-09-25T15:57:36Z",
+        "run_started_at": "2023-09-25T15:55:47Z",
       } as unknown as Workflow;
 
       const workflowJobs = [{
@@ -339,6 +343,81 @@ ${workflowJobs[0].steps![2].name} (0s) :job0-3, after job0-2, 0s
       assertEquals(createGantt(workflow, workflowJobs), expect);
     },
   );
+
+  await t.step("retried job", () => {
+    const workflow = {
+      "id": 5833450919,
+      "name": "Check self-hosted runner",
+      "run_number": 128,
+      "event": "workflow_dispatch",
+      "status": "completed",
+      "conclusion": "success",
+      "workflow_id": 10970418,
+      // Retried job does not changed created_at but changed run_started_at.
+      // This dummy simulate to retry job after 1 hour.
+      "created_at": "2023-08-11T13:00:48Z",
+      "updated_at": "2023-08-11T14:01:56Z",
+      "run_started_at": "2023-08-11T14:00:48Z",
+      "run_attempt": 2,
+    } as unknown as Workflow;
+
+    const workflowJobs = [
+      {
+        "id": 15820938470,
+        "run_id": 5833450919,
+        "workflow_name": "Check self-hosted runner",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2023-08-11T14:00:50Z",
+        "started_at": "2023-08-11T14:01:31Z",
+        "completed_at": "2023-08-11T14:01:36Z",
+        "name": "node",
+        "steps": [
+          {
+            "name": "Set up job",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 1,
+            "started_at": "2023-08-11T23:01:30.000+09:00",
+            "completed_at": "2023-08-11T23:01:32.000+09:00",
+          },
+          {
+            "name": "Set up runner",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 2,
+            "started_at": "2023-08-11T23:01:32.000+09:00",
+            "completed_at": "2023-08-11T23:01:32.000+09:00",
+          },
+          {
+            "name": "Run actions/checkout@v3",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 3,
+            "started_at": "2023-08-11T23:01:34.000+09:00",
+            "completed_at": "2023-08-11T23:01:34.000+09:00",
+          },
+        ],
+      },
+    ] as unknown as WorkflowJobs;
+
+    // deno-fmt-ignore
+    const expect = `
+\`\`\`mermaid
+gantt
+title ${workflowJobs[0].workflow_name}
+dateFormat  HH:mm:ss
+axisFormat  %H:%M:%S
+section ${workflowJobs[0].name}
+Waiting for a runner (41s) :active, job0-0, 00:00:02, 41s
+${workflowJobs[0].steps![0].name} (2s) :job0-1, after job0-0, 2s
+${workflowJobs[0].steps![1].name} (0s) :job0-2, after job0-1, 0s
+${workflowJobs[0].steps![2].name} (0s) :job0-3, after job0-2, 0s
+\`\`\`
+`;
+
+    assertEquals(createGantt(workflow, workflowJobs), expect);
+  });
 });
 
 Deno.test("2 section gantt", async (t) => {
@@ -353,6 +432,7 @@ Deno.test("2 section gantt", async (t) => {
       "workflow_id": 10970418,
       "created_at": "2023-08-11T14:00:48Z",
       "updated_at": "2023-08-11T14:01:56Z",
+      "run_started_at": "2023-08-11T14:00:48Z",
     } as unknown as Workflow;
 
     const workflowJobs = [
@@ -547,6 +627,7 @@ ${workflowJobs[1].steps![6].name} (0s) :job1-7, after job1-6, 0s
       "workflow_id": 10970418,
       "created_at": "2023-08-11T14:00:48Z",
       "updated_at": "2023-08-11T14:01:56Z",
+      "run_started_at": "2023-08-11T14:00:48Z",
     } as unknown as Workflow;
 
     const workflowJobs = [


### PR DESCRIPTION
https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#get-a-workflow-run

```
    "run_started_at": {
      "type": "string",
      "format": "date-time",
      "description": "The start time of the latest run. Resets on re-run."
    },
```

`created_at` does not reset on re-run.