### PR TITLE
Omit duration sec for waiting runner step in < GHES v3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ You can set `GITHUB_API_URL` environment variable to use this action with GHES.
     GITHUB_API_URL: 'https://github.example.com/api/v3'
 ```
 
+## Known issues
+
+### 'Waiting for a runner' step is not supported < GHES v3.9
+
+GET `workflow_job` API response does not contain `created_at` field in [GHES v3.8](https://docs.github.com/en/enterprise-server@3.8/rest/actions/workflow-jobs#get-a-job-for-a-workflow-run), it is added from [GHES v3.9](https://docs.github.com/en/enterprise-server@3.9/rest/actions/workflow-jobs?apiVersion=2022-11-28). So it is not possible to calculate the elapsed time the runner is waiting for a job, `actions-timeline` inserts a dummy step instead.
+
 # DEVELOPMENT
 
 ## Setup

--- a/dist/post.js
+++ b/dist/post.js
@@ -24859,12 +24859,13 @@ var createWaitingRunnerStep = (workflow, job, jobIndex) => {
       workflow.run_started_at,
       job.started_at
     );
-    const waitingRunnerElapsedSec = diffSec(job.created_at, job.started_at);
+    const waitingRunnerElapsedSec = startJobElapsedSec;
     return {
       name: `Waiting for a runner (not supported < GHES v3.9)`,
       id: `job${jobIndex}-0`,
       status,
-      position: formatElapsedTime(startJobElapsedSec),
+      // dummy position for gantt look and feel
+      position: formatElapsedTime(0),
       sec: waitingRunnerElapsedSec
     };
   } else {

--- a/dist/post.js
+++ b/dist/post.js
@@ -24859,13 +24859,13 @@ var createWaitingRunnerStep = (workflow, job, jobIndex) => {
       workflow.run_started_at,
       job.started_at
     );
-    const waitingRunnerElapsedSec = diffSec(job.created_at, job.started_at);
     return {
       name: `Waiting for a runner (not supported < GHES v3.9)`,
       id: `job${jobIndex}-0`,
       status,
       position: formatElapsedTime(startJobElapsedSec),
-      sec: waitingRunnerElapsedSec
+      sec: 1
+      // dummy sec for gantt look and feel
     };
   } else {
     const startJobElapsedSec = diffSec(

--- a/dist/post.js
+++ b/dist/post.js
@@ -24859,13 +24859,13 @@ var createWaitingRunnerStep = (workflow, job, jobIndex) => {
       workflow.run_started_at,
       job.started_at
     );
+    const waitingRunnerElapsedSec = diffSec(job.created_at, job.started_at);
     return {
       name: `Waiting for a runner (not supported < GHES v3.9)`,
       id: `job${jobIndex}-0`,
       status,
       position: formatElapsedTime(startJobElapsedSec),
-      sec: 1
-      // dummy sec for gantt look and feel
+      sec: waitingRunnerElapsedSec
     };
   } else {
     const startJobElapsedSec = diffSec(

--- a/src/workflow_gantt.ts
+++ b/src/workflow_gantt.ts
@@ -115,10 +115,9 @@ const createWaitingRunnerStep = (
 ): ganttStep => {
   const status: ganttStep["status"] = "active";
 
-  // job.created_at is not appered in < GHES v3.9
-  // So it it not possible to calculate the elapsed time that runner waiting for a job,
-  // print it is not supported instead of the elapsed time.
-  // Also, it is not possible to create accurate job start time position. So use job.started_at instead of job.created_at.
+  // job.created_at does not exist in < GHES v3.9.
+  // So it is not possible to calculate the elapsed time the runner is waiting for a job, is not supported instead of the elapsed time.
+  // Also, it is not possible to create an exact job start time position. So use job.started_at instead of job.created_at.
   if (job.created_at === undefined) {
     const startJobElapsedSec = diffSec(
       workflow.run_started_at,

--- a/src/workflow_gantt.ts
+++ b/src/workflow_gantt.ts
@@ -124,14 +124,17 @@ const createWaitingRunnerStep = (
       workflow.run_started_at,
       job.started_at,
     );
-    const waitingRunnerElapsedSec = diffSec(job.created_at, job.started_at);
+    // dummy sec for gantt look and feel
+    const waitingRunnerElapsedSec = startJobElapsedSec;
     return {
       name: `Waiting for a runner (not supported < GHES v3.9)`,
       id: `job${jobIndex}-0`,
       status,
-      position: formatElapsedTime(startJobElapsedSec),
+      // dummy position for gantt look and feel
+      position: formatElapsedTime(0),
       sec: waitingRunnerElapsedSec,
     };
+    // >= GHES v3.9 or GitHub.com
   } else {
     const startJobElapsedSec = diffSec(
       workflow.run_started_at,

--- a/src/workflow_gantt.ts
+++ b/src/workflow_gantt.ts
@@ -124,14 +124,14 @@ const createWaitingRunnerStep = (
       workflow.run_started_at,
       job.started_at,
     );
-    const waitingRunnerElapsedSec = diffSec(job.created_at, job.started_at);
     return {
       name: `Waiting for a runner (not supported < GHES v3.9)`,
       id: `job${jobIndex}-0`,
       status,
       position: formatElapsedTime(startJobElapsedSec),
-      sec: waitingRunnerElapsedSec,
+      sec: 1, // dummy sec for gantt look and feel
     };
+    // >= GHES v3.9 or GitHub.com
   } else {
     const startJobElapsedSec = diffSec(
       workflow.run_started_at,

--- a/src/workflow_gantt.ts
+++ b/src/workflow_gantt.ts
@@ -124,14 +124,14 @@ const createWaitingRunnerStep = (
       workflow.run_started_at,
       job.started_at,
     );
+    const waitingRunnerElapsedSec = diffSec(job.created_at, job.started_at);
     return {
       name: `Waiting for a runner (not supported < GHES v3.9)`,
       id: `job${jobIndex}-0`,
       status,
       position: formatElapsedTime(startJobElapsedSec),
-      sec: 1, // dummy sec for gantt look and feel
+      sec: waitingRunnerElapsedSec,
     };
-    // >= GHES v3.9 or GitHub.com
   } else {
     const startJobElapsedSec = diffSec(
       workflow.run_started_at,

--- a/tests/workflow_gantt_test.ts
+++ b/tests/workflow_gantt_test.ts
@@ -769,7 +769,7 @@ title ${workflowJobs[0].workflow_name}
 dateFormat  HH:mm:ss
 axisFormat  %H:%M:%S
 section ${workflowJobs[0].name}
-Waiting for a runner (not supported < GHES v3.9) :active, job0-0, 00:00:43, 1s
+Waiting for a runner (not supported < GHES v3.9) :active, job0-0, 00:00:43, 0s
 ${workflowJobs[0].steps![0].name} (2s) :job0-1, after job0-0, 2s
 ${workflowJobs[0].steps![1].name} (0s) :job0-2, after job0-1, 0s
 ${workflowJobs[0].steps![2].name} (0s) :job0-3, after job0-2, 0s

--- a/tests/workflow_gantt_test.ts
+++ b/tests/workflow_gantt_test.ts
@@ -724,7 +724,7 @@ ${workflowJobs[0].steps![2].name} (0s) :job0-3, after job0-2, 0s
           "workflow_name": "Check self-hosted runner",
           "status": "completed",
           "conclusion": "success",
-          // "created_at" field is not exists before GHES v3.9.
+          // "created_at" field does not exists before GHES v3.9.
           // GHES v3.8 https://docs.github.com/en/enterprise-server@3.8/rest/actions/workflow-jobs#list-jobs-for-a-workflow-run-attempt
           // GHES v3.9 https://docs.github.com/en/enterprise-server@3.9/rest/actions/workflow-jobs?apiVersion=2022-11-28#list-jobs-for-a-workflow-run-attempt
           // To emulate < GHES v3.9, just comment out this fixture.

--- a/tests/workflow_gantt_test.ts
+++ b/tests/workflow_gantt_test.ts
@@ -769,7 +769,7 @@ title ${workflowJobs[0].workflow_name}
 dateFormat  HH:mm:ss
 axisFormat  %H:%M:%S
 section ${workflowJobs[0].name}
-Waiting for a runner (not supported < GHES v3.9) :active, job0-0, 00:00:43, 0s
+Waiting for a runner (not supported < GHES v3.9) :active, job0-0, 00:00:43, 1s
 ${workflowJobs[0].steps![0].name} (2s) :job0-1, after job0-0, 2s
 ${workflowJobs[0].steps![1].name} (0s) :job0-2, after job0-1, 0s
 ${workflowJobs[0].steps![2].name} (0s) :job0-3, after job0-2, 0s

--- a/tests/workflow_gantt_test.ts
+++ b/tests/workflow_gantt_test.ts
@@ -769,7 +769,7 @@ title ${workflowJobs[0].workflow_name}
 dateFormat  HH:mm:ss
 axisFormat  %H:%M:%S
 section ${workflowJobs[0].name}
-Waiting for a runner (not supported < GHES v3.9) :active, job0-0, 00:00:43, 0s
+Waiting for a runner (not supported < GHES v3.9) :active, job0-0, 00:00:00, 43s
 ${workflowJobs[0].steps![0].name} (2s) :job0-1, after job0-0, 2s
 ${workflowJobs[0].steps![1].name} (0s) :job0-2, after job0-1, 0s
 ${workflowJobs[0].steps![2].name} (0s) :job0-3, after job0-2, 0s

--- a/tests/workflow_gantt_test.ts
+++ b/tests/workflow_gantt_test.ts
@@ -202,7 +202,7 @@ ${workflowJobs[0].steps![3].name} (0s) :job0-4, after job0-3, 0s
     assertEquals(createGantt(workflow, workflowJobs), expect);
   });
 
-  await t.step("Hide not completed stesp", () => {
+  await t.step("Hide not completed steps", () => {
     const workflow = {
       "id": 6290960492,
       "name": "CI",
@@ -263,156 +263,6 @@ axisFormat  %H:%M:%S
 section ${workflowJobs[0].name}
 Waiting for a runner (6s) :active, job0-0, 00:04:31, 6s
 ${workflowJobs[0].steps![0].name} (1s) :job0-1, after job0-0, 1s
-\`\`\`
-`;
-
-    assertEquals(createGantt(workflow, workflowJobs), expect);
-  });
-
-  await t.step(
-    "colon in job name or step name is deleted",
-    () => {
-      const workflow = {
-        "id": 6301810753,
-        "name": "CI",
-        "run_number": 60,
-        "event": "pull_request",
-        "status": "in_progress",
-        "conclusion": null,
-        "workflow_id": 69674074,
-        "created_at": "2023-09-25T15:55:47Z",
-        "updated_at": "2023-09-25T15:57:36Z",
-        "run_started_at": "2023-09-25T15:55:47Z",
-      } as unknown as Workflow;
-
-      const workflowJobs = [{
-        "id": 17107722147,
-        "run_id": 6301810753,
-        "workflow_name": "CI",
-        "status": "completed",
-        "conclusion": "success",
-        "created_at": "2023-09-25T15:55:50Z",
-        "started_at": "2023-09-25T15:55:56Z",
-        "completed_at": "2023-09-25T15:56:06Z",
-        "name": "check: deno 1.36.1",
-        "steps": [
-          {
-            "name": "Set up job",
-            "status": "completed",
-            "conclusion": "success",
-            "number": 1,
-            "started_at": "2023-09-25T15:55:56.000Z",
-            "completed_at": "2023-09-25T15:55:57.000Z",
-          },
-          {
-            "name": "check: deno",
-            "status": "completed",
-            "conclusion": "success",
-            "number": 2,
-            "started_at": "2023-09-25T15:55:57.000Z",
-            "completed_at": "2023-09-25T15:55:58.000Z",
-          },
-          {
-            "name": "Complete job",
-            "status": "completed",
-            "conclusion": "success",
-            "number": 3,
-            "started_at": "2023-09-25T15:56:03.000Z",
-            "completed_at": "2023-09-25T15:56:03.000Z",
-          },
-        ],
-      }] as unknown as WorkflowJobs;
-
-      const expectJobName = "check deno 1.36.1";
-      const expectStepName = "check deno";
-      // deno-fmt-ignore
-      const expect = `
-\`\`\`mermaid
-gantt
-title ${workflowJobs[0].workflow_name}
-dateFormat  HH:mm:ss
-axisFormat  %H:%M:%S
-section ${expectJobName}
-Waiting for a runner (6s) :active, job0-0, 00:00:03, 6s
-${workflowJobs[0].steps![0].name} (1s) :job0-1, after job0-0, 1s
-${expectStepName} (1s) :job0-2, after job0-1, 1s
-${workflowJobs[0].steps![2].name} (0s) :job0-3, after job0-2, 0s
-\`\`\`
-`;
-
-      assertEquals(createGantt(workflow, workflowJobs), expect);
-    },
-  );
-
-  await t.step("retried job", () => {
-    const workflow = {
-      "id": 5833450919,
-      "name": "Check self-hosted runner",
-      "run_number": 128,
-      "event": "workflow_dispatch",
-      "status": "completed",
-      "conclusion": "success",
-      "workflow_id": 10970418,
-      // Retried job does not changed created_at but changed run_started_at.
-      // This dummy simulate to retry job after 1 hour.
-      "created_at": "2023-08-11T13:00:48Z",
-      "updated_at": "2023-08-11T14:01:56Z",
-      "run_started_at": "2023-08-11T14:00:48Z",
-      "run_attempt": 2,
-    } as unknown as Workflow;
-
-    const workflowJobs = [
-      {
-        "id": 15820938470,
-        "run_id": 5833450919,
-        "workflow_name": "Check self-hosted runner",
-        "status": "completed",
-        "conclusion": "success",
-        "created_at": "2023-08-11T14:00:50Z",
-        "started_at": "2023-08-11T14:01:31Z",
-        "completed_at": "2023-08-11T14:01:36Z",
-        "name": "node",
-        "steps": [
-          {
-            "name": "Set up job",
-            "status": "completed",
-            "conclusion": "success",
-            "number": 1,
-            "started_at": "2023-08-11T23:01:30.000+09:00",
-            "completed_at": "2023-08-11T23:01:32.000+09:00",
-          },
-          {
-            "name": "Set up runner",
-            "status": "completed",
-            "conclusion": "success",
-            "number": 2,
-            "started_at": "2023-08-11T23:01:32.000+09:00",
-            "completed_at": "2023-08-11T23:01:32.000+09:00",
-          },
-          {
-            "name": "Run actions/checkout@v3",
-            "status": "completed",
-            "conclusion": "success",
-            "number": 3,
-            "started_at": "2023-08-11T23:01:34.000+09:00",
-            "completed_at": "2023-08-11T23:01:34.000+09:00",
-          },
-        ],
-      },
-    ] as unknown as WorkflowJobs;
-
-    // deno-fmt-ignore
-    const expect = `
-\`\`\`mermaid
-gantt
-title ${workflowJobs[0].workflow_name}
-dateFormat  HH:mm:ss
-axisFormat  %H:%M:%S
-section ${workflowJobs[0].name}
-Waiting for a runner (41s) :active, job0-0, 00:00:02, 41s
-${workflowJobs[0].steps![0].name} (2s) :job0-1, after job0-0, 2s
-${workflowJobs[0].steps![1].name} (0s) :job0-2, after job0-1, 0s
-${workflowJobs[0].steps![2].name} (0s) :job0-3, after job0-2, 0s
 \`\`\`
 `;
 
@@ -679,6 +529,157 @@ ${workflowJobs[1].steps![6].name} (0s) :job1-7, after job1-6, 0s
         "completed_at": "2023-08-11T14:01:50Z",
         "name": "skipped test",
         "steps": [],
+      },
+    ] as unknown as WorkflowJobs;
+
+    // deno-fmt-ignore
+    const expect = `
+\`\`\`mermaid
+gantt
+title ${workflowJobs[0].workflow_name}
+dateFormat  HH:mm:ss
+axisFormat  %H:%M:%S
+section ${workflowJobs[0].name}
+Waiting for a runner (41s) :active, job0-0, 00:00:02, 41s
+${workflowJobs[0].steps![0].name} (2s) :job0-1, after job0-0, 2s
+${workflowJobs[0].steps![1].name} (0s) :job0-2, after job0-1, 0s
+${workflowJobs[0].steps![2].name} (0s) :job0-3, after job0-2, 0s
+\`\`\`
+`;
+
+    assertEquals(createGantt(workflow, workflowJobs), expect);
+  });
+});
+
+Deno.test("Special case gantt", async (t) => {
+  await t.step(
+    "Escape colon char in job name or step name",
+    () => {
+      const workflow = {
+        "id": 6301810753,
+        "name": "CI",
+        "run_number": 60,
+        "event": "pull_request",
+        "status": "in_progress",
+        "conclusion": null,
+        "workflow_id": 69674074,
+        "created_at": "2023-09-25T15:55:47Z",
+        "updated_at": "2023-09-25T15:57:36Z",
+        "run_started_at": "2023-09-25T15:55:47Z",
+      } as unknown as Workflow;
+
+      const workflowJobs = [{
+        "id": 17107722147,
+        "run_id": 6301810753,
+        "workflow_name": "CI",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2023-09-25T15:55:50Z",
+        "started_at": "2023-09-25T15:55:56Z",
+        "completed_at": "2023-09-25T15:56:06Z",
+        "name": "check: deno 1.36.1",
+        "steps": [
+          {
+            "name": "Set up job",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 1,
+            "started_at": "2023-09-25T15:55:56.000Z",
+            "completed_at": "2023-09-25T15:55:57.000Z",
+          },
+          {
+            "name": "check: deno",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 2,
+            "started_at": "2023-09-25T15:55:57.000Z",
+            "completed_at": "2023-09-25T15:55:58.000Z",
+          },
+          {
+            "name": "Complete job",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 3,
+            "started_at": "2023-09-25T15:56:03.000Z",
+            "completed_at": "2023-09-25T15:56:03.000Z",
+          },
+        ],
+      }] as unknown as WorkflowJobs;
+
+      const expectJobName = "check deno 1.36.1";
+      const expectStepName = "check deno";
+      // deno-fmt-ignore
+      const expect = `
+\`\`\`mermaid
+gantt
+title ${workflowJobs[0].workflow_name}
+dateFormat  HH:mm:ss
+axisFormat  %H:%M:%S
+section ${expectJobName}
+Waiting for a runner (6s) :active, job0-0, 00:00:03, 6s
+${workflowJobs[0].steps![0].name} (1s) :job0-1, after job0-0, 1s
+${expectStepName} (1s) :job0-2, after job0-1, 1s
+${workflowJobs[0].steps![2].name} (0s) :job0-3, after job0-2, 0s
+\`\`\`
+`;
+
+      assertEquals(createGantt(workflow, workflowJobs), expect);
+    },
+  );
+  await t.step("Retried job", () => {
+    const workflow = {
+      "id": 5833450919,
+      "name": "Check self-hosted runner",
+      "run_number": 128,
+      "event": "workflow_dispatch",
+      "status": "completed",
+      "conclusion": "success",
+      "workflow_id": 10970418,
+      // Retried job does not changed created_at but changed run_started_at.
+      // This dummy simulate to retry job after 1 hour.
+      "created_at": "2023-08-11T13:00:48Z",
+      "updated_at": "2023-08-11T14:01:56Z",
+      "run_started_at": "2023-08-11T14:00:48Z",
+      "run_attempt": 2,
+    } as unknown as Workflow;
+
+    const workflowJobs = [
+      {
+        "id": 15820938470,
+        "run_id": 5833450919,
+        "workflow_name": "Check self-hosted runner",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2023-08-11T14:00:50Z",
+        "started_at": "2023-08-11T14:01:31Z",
+        "completed_at": "2023-08-11T14:01:36Z",
+        "name": "node",
+        "steps": [
+          {
+            "name": "Set up job",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 1,
+            "started_at": "2023-08-11T23:01:30.000+09:00",
+            "completed_at": "2023-08-11T23:01:32.000+09:00",
+          },
+          {
+            "name": "Set up runner",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 2,
+            "started_at": "2023-08-11T23:01:32.000+09:00",
+            "completed_at": "2023-08-11T23:01:32.000+09:00",
+          },
+          {
+            "name": "Run actions/checkout@v3",
+            "status": "completed",
+            "conclusion": "success",
+            "number": 3,
+            "started_at": "2023-08-11T23:01:34.000+09:00",
+            "completed_at": "2023-08-11T23:01:34.000+09:00",
+          },
+        ],
       },
     ] as unknown as WorkflowJobs;
 


### PR DESCRIPTION
GET `workflow_job` API response does not contain `created_at` field in [GHES v3.8](https://docs.github.com/en/enterprise-server@3.8/rest/actions/workflow-jobs#get-a-job-for-a-workflow-run), it is added from [GHES v3.9](https://docs.github.com/en/enterprise-server@3.9/rest/actions/workflow-jobs?apiVersion=2022-11-28). 

So it is not possible to calculate the elapsed time the runner is waiting for a job, `actions-timeline` inserts a dummy step instead.