### PR TITLE
ci: Add rebundle dist/ workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,7 @@ jobs:
       - uses: ./.github/actions/setup-deno-with-cache
       - name: Rebuild the dist/ directory
         run: deno task bundle
-      - name: Compare the expected and actual dist/ directories
-        run: |
-          if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
-            echo "Detected uncommitted changes after build.  See status below:"
-            git diff
-            exit 1
-          fi
+        
       # post processes
       - name: Upload dist for post job
         if: ${{ always() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/rebundle.yml
+++ b/.github/workflows/rebundle.yml
@@ -1,0 +1,34 @@
+name: Rebundle dist
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  # Rebundle dist and push if changed from main branch
+  rebundle-dist:
+    runs-on: ubuntu-latest
+    steps:
+      # To bypass branch rule sets, we need to use GitHub App that allowed to bypass status check.
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.BYPASS_APP_ID }}
+          private-key: ${{ secrets.BYPASS_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: ./.github/actions/setup-deno-with-cache
+      - name: Rebuild the dist/ directory
+        run: deno task bundle
+      - name: Commit and push dist/ if changed
+        run: |
+          if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
+            git config --global user.name "github-actions"
+            git config --global user.email "github-actions@github.com"
+            git add -u dist
+            git commit -m "deno task bundle"
+            git push origin main
+          fi


### PR DESCRIPTION
This pull request adds a new workflow to rebundle the `dist/` directory on push to the `main` branch. It also disables checking the `dist/` diff at pull_request. This change ensures that the `dist/` directory is always up-to-date and avoids unnecessary checks during pull requests.
(Generated by GitHub Copilot)

----
The `deno task bundle` generated `dist/` changes frequently so it is incompatible with `Renovate`. To solve this problem, CI automatically pushes diffs instead of checking diffs in pull_request.
