### PR TITLE
Keep composite parent bars in expanded gantt output

### DIFF
--- a/.claude/skills/verify-composite-expansion/SKILL.md
+++ b/.claude/skills/verify-composite-expansion/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify-composite-expansion
-description: Verify composite action expansion output by comparing CLI-generated mermaid charts with actual GitHub Actions logs. Use when testing or debugging the --expand-composite-actions feature against any GitHub Actions workflow run. Triggered by requests like "composite展開を検証", "verify composite expansion", or "compare CLI output with logs".
+description: Verify composite action expansion output by comparing CLI-generated mermaid charts with actual GitHub Actions logs. Use when testing or debugging the --expand-composite-actions feature, especially to confirm that the original composite bar remains visible while expanded child rows appear beneath it. Triggered by requests like "composite展開を検証", "verify composite expansion", or "compare CLI output with logs".
 ---
 
 # Verify Composite Expansion
@@ -51,7 +51,7 @@ List jobs:
 gh run -R {org}/{repo} view {run_id}
 ```
 
-Get step details for a job (gaps in step numbers indicate composite sub-steps):
+Get step details for a job (gaps in step numbers help identify composite internals in logs):
 
 ```bash
 gh api repos/{org}/{repo}/actions/jobs/{job_id} --jq '.steps[] | "\(.number)\t\(.name)\t\(.started_at)\t\(.completed_at)"'
@@ -68,6 +68,7 @@ gh run -R {org}/{repo} view --job={job_id} --log
 When comparing outputs, check:
 
 - **Without expansion**: Composite actions appear as a single step (e.g., "Prepare (25s)")
-- **With expansion**: That step is expanded into sub-steps with `(sub)` prefix
-- **API step numbers**: Gaps in numbering correspond to composite sub-steps
-- **Time consistency**: Total duration of sub-steps roughly matches the single composite step duration
+- **With expansion**: The original composite step still appears, and expanded child rows with `(sub)` prefix are rendered beneath it
+- **API step mapping**: The preserved composite parent should still line up with the API step list and workflow YAML
+- **Time consistency**: Child row start/end times should fit within the parent composite duration, and the next top-level step should start after the parent completes
+- **Log consistency**: Child row ordering and names should be traceable to the grouped job log blocks

--- a/.claude/skills/verify-composite-expansion/scripts/verify_composite.sh
+++ b/.claude/skills/verify-composite-expansion/scripts/verify_composite.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # Verify composite action expansion by comparing CLI output with actual GitHub Actions logs.
+# The expanded output should keep the original composite bar and add child rows
+# beneath it when expansion succeeds.
 #
 # Usage:
 #   verify_composite.sh <org/repo> <run_id> [output_dir]
@@ -73,5 +75,5 @@ done
 
 echo "=== Done ==="
 echo "Compare the following files:"
-echo "  Composite: ${COMPOSITE_OUT}"
+echo "  Composite-expanded: ${COMPOSITE_OUT}"
 echo "  Normal:    ${NORMAL_OUT}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,9 @@ jobs:
         uses: ./
         with:
           expand-composite-actions: true
-      - name: Run self action with 'expand-composite-actions=true' and 'expand-composite-actions-threshold=5'
+      - name: Run self action with 'expand-composite-actions=true' and 'expand-composite-actions-threshold'
         uses: ./
         with:
           expand-composite-actions: true
-          expand-composite-actions-threshold: 5
+          # Always expand composite actions for dogfooding
+          expand-composite-actions-threshold: 1

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ jobs:
           # Show waiting runner time in the timeline.
           # Default: true
           show-waiting-runner: true
-          # Expand repo-local composite action steps in the timeline.
+          # Expand repo-local composite action steps in the timeline while
+          # keeping the original composite bar and showing expanded sub-steps
+          # beneath it.
           # Note: This option requires additional API calls to fetch job logs
           # and workflow files, which may increase execution time.
           # Limitation: Composite actions that contain nested local composite
@@ -140,7 +142,7 @@ deno run --allow-net --allow-write --allow-env=GITHUB_API_URL \
 ```
 
 ```bash
-# Expand composite action steps
+# Expand composite action steps while keeping the parent composite bar
 deno run --allow-net --allow-write --allow-env=GITHUB_API_URL \
   https://raw.githubusercontent.com/Kesin11/actions-timeline/main/cli.ts \
   https://github.com/OWNER/REPO/actions/runs/RUN_ID \

--- a/deno.lock
+++ b/deno.lock
@@ -7,9 +7,9 @@
     "jsr:@cliffy/table@1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@david/code-block-writer@^13.0.3": "13.0.3",
     "jsr:@deno/dnt@0.42.3": "0.42.3",
-    "jsr:@kesin11/gha-utils@0.2.3": "0.2.3",
+    "jsr:@kesin11/gha-utils@0.3.0": "0.3.0",
     "jsr:@std/assert@^1.0.13": "1.0.13",
-    "jsr:@std/collections@^1.1.2": "1.1.3",
+    "jsr:@std/collections@^1.1.2": "1.1.6",
     "jsr:@std/encoding@^1.0.10": "1.0.10",
     "jsr:@std/fmt@1": "1.0.8",
     "jsr:@std/fmt@~1.0.2": "1.0.8",
@@ -20,19 +20,19 @@
     "jsr:@std/path@1": "1.1.2",
     "jsr:@std/path@^1.1.1": "1.1.2",
     "jsr:@std/text@~1.0.7": "1.0.15",
-    "jsr:@std/yaml@^1.0.11": "1.0.11",
-    "jsr:@std/yaml@^1.0.8": "1.0.11",
+    "jsr:@std/yaml@^1.0.11": "1.0.12",
+    "jsr:@std/yaml@^1.0.8": "1.0.12",
     "jsr:@ts-morph/bootstrap@0.27": "0.27.0",
     "jsr:@ts-morph/common@0.27": "0.27.0",
     "npm:@actions/core@2.0.3": "2.0.3",
     "npm:@actions/github@7.0.0": "7.0.0_@octokit+core@5.2.2",
-    "npm:@octokit/plugin-retry@^8.0.1": "8.0.3_@octokit+core@7.0.6",
+    "npm:@octokit/plugin-retry@^8.0.1": "8.1.0_@octokit+core@7.0.6",
     "npm:@octokit/plugin-throttling@^11.0.1": "11.0.3_@octokit+core@7.0.6",
-    "npm:@octokit/rest@22": "22.0.1_@octokit+core@7.0.6",
+    "npm:@octokit/rest@22": "22.0.1",
     "npm:@types/node@*": "22.15.15",
     "npm:date-fns@4.1.0": "4.1.0",
     "npm:esbuild@0.25.5": "0.25.5",
-    "npm:esbuild@0.27.3": "0.27.3",
+    "npm:esbuild@0.28.0": "0.28.0",
     "npm:structured-source@4": "4.0.0",
     "npm:yaml-ast-parser@^0.0.43": "0.0.43"
   },
@@ -75,8 +75,8 @@
         "jsr:@ts-morph/bootstrap"
       ]
     },
-    "@kesin11/gha-utils@0.2.3": {
-      "integrity": "74b582ec168197998258c80d21976cc0d63fb7448404959b2a59451a0ddbe195",
+    "@kesin11/gha-utils@0.3.0": {
+      "integrity": "7a6b6df05d4c60a7d3c89c2a9c1548b272334a12d03a614b0e2c76ec62a5e052",
       "dependencies": [
         "jsr:@std/collections",
         "jsr:@std/encoding",
@@ -94,8 +94,8 @@
         "jsr:@std/internal@^1.0.6"
       ]
     },
-    "@std/collections@1.1.3": {
-      "integrity": "bf8b0818886df6a32b64c7d3b037a425111f28278d69fd0995aeb62777c986b0"
+    "@std/collections@1.1.6": {
+      "integrity": "b458160ce65ea5ad35da05d0a5cbee4b583677c8b443a10d7beb0c4ac63f2baa"
     },
     "@std/encoding@1.0.10": {
       "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
@@ -125,8 +125,8 @@
     "@std/yaml@1.0.9": {
       "integrity": "6bad3dc766dd85b4b37eabcba81b6aa4eac7a392792ae29abcfb0f90602d55bb"
     },
-    "@std/yaml@1.0.11": {
-      "integrity": "bd139ce77f2d06cbed3713c8b26d301d2a2e12ecc7986130a268107e212143ee"
+    "@std/yaml@1.0.12": {
+      "integrity": "7deabca4545bcedd07c5f69ea53acea71b8b4c67562f224e17b90d75944cb20c"
     },
     "@ts-morph/bootstrap@0.27.0": {
       "integrity": "b8d7bc8f7942ce853dde4161b28f9aa96769cef3d8eebafb379a81800b9e2448",
@@ -183,8 +183,8 @@
       "os": ["aix"],
       "cpu": ["ppc64"]
     },
-    "@esbuild/aix-ppc64@0.27.3": {
-      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+    "@esbuild/aix-ppc64@0.28.0": {
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
       "os": ["aix"],
       "cpu": ["ppc64"]
     },
@@ -193,8 +193,8 @@
       "os": ["android"],
       "cpu": ["arm64"]
     },
-    "@esbuild/android-arm64@0.27.3": {
-      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+    "@esbuild/android-arm64@0.28.0": {
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
       "os": ["android"],
       "cpu": ["arm64"]
     },
@@ -203,8 +203,8 @@
       "os": ["android"],
       "cpu": ["arm"]
     },
-    "@esbuild/android-arm@0.27.3": {
-      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+    "@esbuild/android-arm@0.28.0": {
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
       "os": ["android"],
       "cpu": ["arm"]
     },
@@ -213,8 +213,8 @@
       "os": ["android"],
       "cpu": ["x64"]
     },
-    "@esbuild/android-x64@0.27.3": {
-      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+    "@esbuild/android-x64@0.28.0": {
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
       "os": ["android"],
       "cpu": ["x64"]
     },
@@ -223,8 +223,8 @@
       "os": ["darwin"],
       "cpu": ["arm64"]
     },
-    "@esbuild/darwin-arm64@0.27.3": {
-      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+    "@esbuild/darwin-arm64@0.28.0": {
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
       "os": ["darwin"],
       "cpu": ["arm64"]
     },
@@ -233,8 +233,8 @@
       "os": ["darwin"],
       "cpu": ["x64"]
     },
-    "@esbuild/darwin-x64@0.27.3": {
-      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+    "@esbuild/darwin-x64@0.28.0": {
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
       "os": ["darwin"],
       "cpu": ["x64"]
     },
@@ -243,8 +243,8 @@
       "os": ["freebsd"],
       "cpu": ["arm64"]
     },
-    "@esbuild/freebsd-arm64@0.27.3": {
-      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+    "@esbuild/freebsd-arm64@0.28.0": {
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
       "os": ["freebsd"],
       "cpu": ["arm64"]
     },
@@ -253,8 +253,8 @@
       "os": ["freebsd"],
       "cpu": ["x64"]
     },
-    "@esbuild/freebsd-x64@0.27.3": {
-      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+    "@esbuild/freebsd-x64@0.28.0": {
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
       "os": ["freebsd"],
       "cpu": ["x64"]
     },
@@ -263,8 +263,8 @@
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "@esbuild/linux-arm64@0.27.3": {
-      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+    "@esbuild/linux-arm64@0.28.0": {
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
@@ -273,8 +273,8 @@
       "os": ["linux"],
       "cpu": ["arm"]
     },
-    "@esbuild/linux-arm@0.27.3": {
-      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+    "@esbuild/linux-arm@0.28.0": {
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
       "os": ["linux"],
       "cpu": ["arm"]
     },
@@ -283,8 +283,8 @@
       "os": ["linux"],
       "cpu": ["ia32"]
     },
-    "@esbuild/linux-ia32@0.27.3": {
-      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+    "@esbuild/linux-ia32@0.28.0": {
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
       "os": ["linux"],
       "cpu": ["ia32"]
     },
@@ -293,8 +293,8 @@
       "os": ["linux"],
       "cpu": ["loong64"]
     },
-    "@esbuild/linux-loong64@0.27.3": {
-      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+    "@esbuild/linux-loong64@0.28.0": {
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
       "os": ["linux"],
       "cpu": ["loong64"]
     },
@@ -303,8 +303,8 @@
       "os": ["linux"],
       "cpu": ["mips64el"]
     },
-    "@esbuild/linux-mips64el@0.27.3": {
-      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+    "@esbuild/linux-mips64el@0.28.0": {
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
       "os": ["linux"],
       "cpu": ["mips64el"]
     },
@@ -313,8 +313,8 @@
       "os": ["linux"],
       "cpu": ["ppc64"]
     },
-    "@esbuild/linux-ppc64@0.27.3": {
-      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+    "@esbuild/linux-ppc64@0.28.0": {
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
       "os": ["linux"],
       "cpu": ["ppc64"]
     },
@@ -323,8 +323,8 @@
       "os": ["linux"],
       "cpu": ["riscv64"]
     },
-    "@esbuild/linux-riscv64@0.27.3": {
-      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+    "@esbuild/linux-riscv64@0.28.0": {
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
       "os": ["linux"],
       "cpu": ["riscv64"]
     },
@@ -333,8 +333,8 @@
       "os": ["linux"],
       "cpu": ["s390x"]
     },
-    "@esbuild/linux-s390x@0.27.3": {
-      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+    "@esbuild/linux-s390x@0.28.0": {
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
       "os": ["linux"],
       "cpu": ["s390x"]
     },
@@ -343,8 +343,8 @@
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "@esbuild/linux-x64@0.27.3": {
-      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+    "@esbuild/linux-x64@0.28.0": {
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
@@ -353,8 +353,8 @@
       "os": ["netbsd"],
       "cpu": ["arm64"]
     },
-    "@esbuild/netbsd-arm64@0.27.3": {
-      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+    "@esbuild/netbsd-arm64@0.28.0": {
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
       "os": ["netbsd"],
       "cpu": ["arm64"]
     },
@@ -363,8 +363,8 @@
       "os": ["netbsd"],
       "cpu": ["x64"]
     },
-    "@esbuild/netbsd-x64@0.27.3": {
-      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+    "@esbuild/netbsd-x64@0.28.0": {
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
       "os": ["netbsd"],
       "cpu": ["x64"]
     },
@@ -373,8 +373,8 @@
       "os": ["openbsd"],
       "cpu": ["arm64"]
     },
-    "@esbuild/openbsd-arm64@0.27.3": {
-      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+    "@esbuild/openbsd-arm64@0.28.0": {
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
       "os": ["openbsd"],
       "cpu": ["arm64"]
     },
@@ -383,13 +383,13 @@
       "os": ["openbsd"],
       "cpu": ["x64"]
     },
-    "@esbuild/openbsd-x64@0.27.3": {
-      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+    "@esbuild/openbsd-x64@0.28.0": {
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
       "os": ["openbsd"],
       "cpu": ["x64"]
     },
-    "@esbuild/openharmony-arm64@0.27.3": {
-      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+    "@esbuild/openharmony-arm64@0.28.0": {
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
       "os": ["openharmony"],
       "cpu": ["arm64"]
     },
@@ -398,8 +398,8 @@
       "os": ["sunos"],
       "cpu": ["x64"]
     },
-    "@esbuild/sunos-x64@0.27.3": {
-      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+    "@esbuild/sunos-x64@0.28.0": {
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
       "os": ["sunos"],
       "cpu": ["x64"]
     },
@@ -408,8 +408,8 @@
       "os": ["win32"],
       "cpu": ["arm64"]
     },
-    "@esbuild/win32-arm64@0.27.3": {
-      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+    "@esbuild/win32-arm64@0.28.0": {
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
       "os": ["win32"],
       "cpu": ["arm64"]
     },
@@ -418,8 +418,8 @@
       "os": ["win32"],
       "cpu": ["ia32"]
     },
-    "@esbuild/win32-ia32@0.27.3": {
-      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+    "@esbuild/win32-ia32@0.28.0": {
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
       "os": ["win32"],
       "cpu": ["ia32"]
     },
@@ -428,8 +428,8 @@
       "os": ["win32"],
       "cpu": ["x64"]
     },
-    "@esbuild/win32-x64@0.27.3": {
-      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+    "@esbuild/win32-x64@0.28.0": {
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
       "os": ["win32"],
       "cpu": ["x64"]
     },
@@ -459,15 +459,15 @@
       "dependencies": [
         "@octokit/auth-token@6.0.0",
         "@octokit/graphql@9.0.3",
-        "@octokit/request@10.0.7",
+        "@octokit/request@10.0.8",
         "@octokit/request-error@7.1.0",
         "@octokit/types@16.0.0",
         "before-after-hook@4.0.0",
         "universal-user-agent@7.0.3"
       ]
     },
-    "@octokit/endpoint@11.0.2": {
-      "integrity": "sha512-4zCpzP1fWc7QlqunZ5bSEjxc6yLAlRTnDwKtgXfcI/FxxGoqedDG8V2+xJ60bV2kODqcGB+nATdtap/XYq2NZQ==",
+    "@octokit/endpoint@11.0.3": {
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
       "dependencies": [
         "@octokit/types@16.0.0",
         "universal-user-agent@7.0.3"
@@ -491,7 +491,7 @@
     "@octokit/graphql@9.0.3": {
       "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
       "dependencies": [
-        "@octokit/request@10.0.7",
+        "@octokit/request@10.0.8",
         "@octokit/types@16.0.0",
         "universal-user-agent@7.0.3"
       ]
@@ -539,8 +539,8 @@
         "@octokit/types@16.0.0"
       ]
     },
-    "@octokit/plugin-retry@8.0.3_@octokit+core@7.0.6": {
-      "integrity": "sha512-vKGx1i3MC0za53IzYBSBXcrhmd+daQDzuZfYDd52X5S0M2otf3kVZTVP8bLA3EkU0lTvd1WEC2OlNNa4G+dohA==",
+    "@octokit/plugin-retry@8.1.0_@octokit+core@7.0.6": {
+      "integrity": "sha512-O1FZgXeiGb2sowEr/hYTr6YunGdSAFWnr2fyW39Ah85H8O33ELASQxcvOFF5LE6Tjekcyu2ms4qAzJVhSaJxTw==",
       "dependencies": [
         "@octokit/core@7.0.6",
         "@octokit/request-error@7.1.0",
@@ -570,13 +570,14 @@
         "@octokit/types@16.0.0"
       ]
     },
-    "@octokit/request@10.0.7": {
-      "integrity": "sha512-v93h0i1yu4idj8qFPZwjehoJx4j3Ntn+JhXsdJrG9pYaX6j/XRz2RmasMUHtNgQD39nrv/VwTWSqK0RNXR8upA==",
+    "@octokit/request@10.0.8": {
+      "integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
       "dependencies": [
-        "@octokit/endpoint@11.0.2",
+        "@octokit/endpoint@11.0.3",
         "@octokit/request-error@7.1.0",
         "@octokit/types@16.0.0",
         "fast-content-type-parse",
+        "json-with-bigint",
         "universal-user-agent@7.0.3"
       ]
     },
@@ -589,7 +590,7 @@
         "universal-user-agent@6.0.1"
       ]
     },
-    "@octokit/rest@22.0.1_@octokit+core@7.0.6": {
+    "@octokit/rest@22.0.1": {
       "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
       "dependencies": [
         "@octokit/core@7.0.6",
@@ -672,41 +673,44 @@
       "scripts": true,
       "bin": true
     },
-    "esbuild@0.27.3": {
-      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+    "esbuild@0.28.0": {
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
       "optionalDependencies": [
-        "@esbuild/aix-ppc64@0.27.3",
-        "@esbuild/android-arm@0.27.3",
-        "@esbuild/android-arm64@0.27.3",
-        "@esbuild/android-x64@0.27.3",
-        "@esbuild/darwin-arm64@0.27.3",
-        "@esbuild/darwin-x64@0.27.3",
-        "@esbuild/freebsd-arm64@0.27.3",
-        "@esbuild/freebsd-x64@0.27.3",
-        "@esbuild/linux-arm@0.27.3",
-        "@esbuild/linux-arm64@0.27.3",
-        "@esbuild/linux-ia32@0.27.3",
-        "@esbuild/linux-loong64@0.27.3",
-        "@esbuild/linux-mips64el@0.27.3",
-        "@esbuild/linux-ppc64@0.27.3",
-        "@esbuild/linux-riscv64@0.27.3",
-        "@esbuild/linux-s390x@0.27.3",
-        "@esbuild/linux-x64@0.27.3",
-        "@esbuild/netbsd-arm64@0.27.3",
-        "@esbuild/netbsd-x64@0.27.3",
-        "@esbuild/openbsd-arm64@0.27.3",
-        "@esbuild/openbsd-x64@0.27.3",
+        "@esbuild/aix-ppc64@0.28.0",
+        "@esbuild/android-arm@0.28.0",
+        "@esbuild/android-arm64@0.28.0",
+        "@esbuild/android-x64@0.28.0",
+        "@esbuild/darwin-arm64@0.28.0",
+        "@esbuild/darwin-x64@0.28.0",
+        "@esbuild/freebsd-arm64@0.28.0",
+        "@esbuild/freebsd-x64@0.28.0",
+        "@esbuild/linux-arm@0.28.0",
+        "@esbuild/linux-arm64@0.28.0",
+        "@esbuild/linux-ia32@0.28.0",
+        "@esbuild/linux-loong64@0.28.0",
+        "@esbuild/linux-mips64el@0.28.0",
+        "@esbuild/linux-ppc64@0.28.0",
+        "@esbuild/linux-riscv64@0.28.0",
+        "@esbuild/linux-s390x@0.28.0",
+        "@esbuild/linux-x64@0.28.0",
+        "@esbuild/netbsd-arm64@0.28.0",
+        "@esbuild/netbsd-x64@0.28.0",
+        "@esbuild/openbsd-arm64@0.28.0",
+        "@esbuild/openbsd-x64@0.28.0",
         "@esbuild/openharmony-arm64",
-        "@esbuild/sunos-x64@0.27.3",
-        "@esbuild/win32-arm64@0.27.3",
-        "@esbuild/win32-ia32@0.27.3",
-        "@esbuild/win32-x64@0.27.3"
+        "@esbuild/sunos-x64@0.28.0",
+        "@esbuild/win32-arm64@0.28.0",
+        "@esbuild/win32-ia32@0.28.0",
+        "@esbuild/win32-x64@0.28.0"
       ],
       "scripts": true,
       "bin": true
     },
     "fast-content-type-parse@3.0.0": {
       "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg=="
+    },
+    "json-with-bigint@3.5.8": {
+      "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw=="
     },
     "once@1.4.0": {
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
@@ -752,7 +756,7 @@
     "dependencies": [
       "jsr:@cliffy/command@^1.0.0-rc.8",
       "jsr:@deno/dnt@0.42.3",
-      "jsr:@kesin11/gha-utils@0.2.3",
+      "jsr:@kesin11/gha-utils@0.3.0",
       "jsr:@std/assert@^1.0.13",
       "jsr:@std/collections@^1.1.2",
       "jsr:@std/encoding@^1.0.10",
@@ -760,7 +764,7 @@
       "npm:@actions/core@2.0.3",
       "npm:@actions/github@7.0.0",
       "npm:date-fns@4.1.0",
-      "npm:esbuild@0.27.3"
+      "npm:esbuild@0.28.0"
     ]
   }
 }

--- a/dist/post.js
+++ b/dist/post.js
@@ -52333,7 +52333,7 @@ var import_node_process = __toESM(require("node:process"));
 var import_core2 = __toESM(require_core());
 var github = __toESM(require_github());
 
-// npm/src/deps/jsr.io/@std/collections/1.1.6/chunk.ts
+// npm/src/deps/jsr.io/@std/collections/1.1.3/chunk.ts
 function chunk(iterable, size) {
   if (size <= 0 || !Number.isInteger(size)) {
     throw new RangeError(
@@ -52363,7 +52363,23 @@ function chunk(iterable, size) {
   return result;
 }
 
-// npm/src/deps/jsr.io/@std/collections/1.1.6/sum_of.ts
+// npm/src/deps/jsr.io/@std/collections/1.1.3/min_of.ts
+function minOf(array, selector) {
+  let minimumValue;
+  for (const element of array) {
+    const currentValue = selector(element);
+    if (minimumValue === void 0 || currentValue < minimumValue) {
+      minimumValue = currentValue;
+      continue;
+    }
+    if (Number.isNaN(currentValue)) {
+      return currentValue;
+    }
+  }
+  return minimumValue;
+}
+
+// npm/src/deps/jsr.io/@std/collections/1.1.3/sum_of.ts
 function sumOf(array, selector) {
   let sum = 0;
   for (const i of array) {
@@ -52372,23 +52388,13 @@ function sumOf(array, selector) {
   return sum;
 }
 
-// npm/src/deps/jsr.io/@std/collections/1.1.6/zip.ts
+// npm/src/deps/jsr.io/@std/collections/1.1.3/zip.ts
 function zip(...arrays) {
-  const { length } = arrays;
-  if (length === 0) return [];
-  let minLength = arrays[0].length;
-  for (let i = 1; i < length; ++i) {
-    if (arrays[i].length < minLength) {
-      minLength = arrays[i].length;
-    }
-  }
+  const minLength = minOf(arrays, (element) => element.length) ?? 0;
   const result = new Array(minLength);
-  for (let i = 0; i < minLength; ++i) {
-    const tuple = new Array(length);
-    for (let j = 0; j < length; ++j) {
-      tuple[j] = arrays[j][i];
-    }
-    result[i] = tuple;
+  for (let i = 0; i < minLength; i += 1) {
+    const arr = arrays.map((it) => it[i]);
+    result[i] = arr;
   }
   return result;
 }
@@ -54036,11 +54042,19 @@ var convertStepToStatus = (conclusion) => {
 
 // npm/src/workflow_gantt.ts
 var MERMAID_MAX_CHAR = 5e4;
+var createGanttStepId = (jobIndex, stepIndex) => `job${jobIndex}-${stepIndex}`;
 var filterSteps = (steps) => {
   return steps.filter((step) => step.status === "completed");
 };
 var filterJobs = (jobs) => {
   return jobs.filter((job) => job.conclusion !== "skipped");
+};
+var createStepPosition = (workflow, jobStartedAt, step, previousTopLevelStepId) => {
+  if (previousTopLevelStepId === void 0) {
+    const startAt = step.timelineRowKind === "composite-child" ? step.started_at : jobStartedAt;
+    return formatElapsedTime(diffSec(workflow.run_started_at, startAt));
+  }
+  return step.timelineRowKind === "composite-child" ? formatElapsedTime(diffSec(workflow.run_started_at, step.started_at)) : `after ${previousTopLevelStepId}`;
 };
 var createWaitingRunnerStep = (workflow, job, jobIndex) => {
   const status = "active";
@@ -54054,7 +54068,7 @@ var createWaitingRunnerStep = (workflow, job, jobIndex) => {
     const waitingRunnerElapsedSec = diffSec(job.created_at, job.started_at);
     return {
       name: formatName("Waiting for a runner", waitingRunnerElapsedSec),
-      id: `job${jobIndex}-0`,
+      id: createGanttStepId(jobIndex, 0),
       status,
       position: formatElapsedTime(startJobElapsedSec),
       sec: waitingRunnerElapsedSec
@@ -54066,48 +54080,39 @@ var createGanttJobs = (workflow, workflowJobs, showWaitingRunner = true) => {
     (job, jobIndex, _jobs) => {
       if (job.steps === void 0) return void 0;
       const section = escapeName(job.name);
-      let firstStep;
+      const completedSteps = filterSteps(job.steps);
+      if (completedSteps.length === 0) return void 0;
+      const steps = [];
+      let previousTopLevelStepId;
       const waitingRunnerStep = createWaitingRunnerStep(
         workflow,
         job,
         jobIndex
       );
-      if (!showWaitingRunner || waitingRunnerStep === void 0) {
-        const rawFirstStep = job.steps.shift();
-        if (rawFirstStep === void 0) return void 0;
-        const startJobElapsedSec = diffSec(
-          workflow.run_started_at,
-          job.started_at
-        );
-        const stepElapsedSec = diffSec(
-          rawFirstStep.started_at,
-          rawFirstStep.completed_at
-        );
-        firstStep = {
-          name: formatName(rawFirstStep.name, stepElapsedSec),
-          id: `job${jobIndex}-0`,
-          status: convertStepToStatus(
-            rawFirstStep.conclusion
-          ),
-          position: formatElapsedTime(startJobElapsedSec),
-          sec: stepElapsedSec
-        };
-      } else {
-        firstStep = waitingRunnerStep;
+      if (showWaitingRunner && waitingRunnerStep !== void 0) {
+        steps.push(waitingRunnerStep);
+        previousTopLevelStepId = waitingRunnerStep.id;
       }
-      const steps = filterSteps(job.steps).map(
-        (step, stepIndex, _steps) => {
-          const stepElapsedSec = diffSec(step.started_at, step.completed_at);
-          return {
-            name: formatName(step.name, stepElapsedSec),
-            id: `job${jobIndex}-${stepIndex + 1}`,
-            status: convertStepToStatus(step.conclusion),
-            position: `after job${jobIndex}-${stepIndex}`,
-            sec: stepElapsedSec
-          };
+      completedSteps.forEach((step) => {
+        const stepElapsedSec = diffSec(step.started_at, step.completed_at);
+        const id = createGanttStepId(jobIndex, steps.length);
+        steps.push({
+          name: formatName(step.name, stepElapsedSec),
+          id,
+          status: convertStepToStatus(step.conclusion),
+          position: createStepPosition(
+            workflow,
+            job.started_at,
+            step,
+            previousTopLevelStepId
+          ),
+          sec: stepElapsedSec
+        });
+        if (step.timelineRowKind !== "composite-child") {
+          previousTopLevelStepId = id;
         }
-      );
-      return { section, steps: [firstStep, ...steps] };
+      });
+      return { section, steps };
     }
   ).filter((gantJobs) => gantJobs !== void 0);
 };
@@ -54272,7 +54277,7 @@ var AB = new ArrayBuffer(8);
 var U32_VIEW = new Uint32Array(AB);
 var U64_VIEW = new BigUint64Array(AB);
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.12/_chars.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.11/_chars.ts
 var TAB = 9;
 var LINE_FEED = 10;
 var CARRIAGE_RETURN = 13;
@@ -54313,7 +54318,7 @@ function isFlowIndicator(c) {
   return c === COMMA || c === LEFT_SQUARE_BRACKET || c === RIGHT_SQUARE_BRACKET || c === LEFT_CURLY_BRACKET || c === RIGHT_CURLY_BRACKET;
 }
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/binary.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/binary.ts
 var BASE64_MAP = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=\n\r";
 function resolveYamlBinary(data) {
   if (data === null) return false;
@@ -54401,7 +54406,7 @@ var binary = {
   resolve: resolveYamlBinary
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/bool.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/bool.ts
 var YAML_TRUE_BOOLEANS = ["true", "True", "TRUE"];
 var YAML_FALSE_BOOLEANS = ["false", "False", "FALSE"];
 var YAML_BOOLEANS = [...YAML_TRUE_BOOLEANS, ...YAML_FALSE_BOOLEANS];
@@ -54431,7 +54436,7 @@ var bool = {
   }
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.12/_utils.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.11/_utils.ts
 function isObject(value) {
   return value !== null && typeof value === "object";
 }
@@ -54442,7 +54447,7 @@ function isPlainObject(object) {
   return Object.prototype.toString.call(object) === "[object Object]";
 }
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/float.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/float.ts
 var YAML_FLOAT_PATTERN = new RegExp(
   // 2.5e4, 2.5 and integers
   "^(?:[-+]?(?:0|[1-9][0-9_]*)(?:\\.[0-9_]*)?(?:[eE][-+]?[0-9]+)?|\\.[0-9_]+(?:[eE][-+]?[0-9]+)?|[-+]?\\.(?:inf|Inf|INF)|\\.(?:nan|NaN|NAN))$"
@@ -54519,7 +54524,7 @@ var float = {
   resolve: resolveYamlFloat
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/int.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/int.ts
 function isCharCodeInRange(c, lower, upper) {
   return lower <= c && c <= upper;
 }
@@ -54641,7 +54646,7 @@ var int = {
   resolve: resolveYamlInteger
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/map.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/map.ts
 var map = {
   tag: "tag:yaml.org,2002:map",
   resolve() {
@@ -54653,7 +54658,7 @@ var map = {
   kind: "mapping"
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/merge.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/merge.ts
 var merge = {
   tag: "tag:yaml.org,2002:merge",
   kind: "scalar",
@@ -54661,7 +54666,7 @@ var merge = {
   construct: (data) => data
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/nil.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/nil.ts
 var nil = {
   tag: "tag:yaml.org,2002:null",
   kind: "scalar",
@@ -54678,7 +54683,7 @@ var nil = {
   }
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/omap.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/omap.ts
 function resolveYamlOmap(data) {
   const objectKeys = /* @__PURE__ */ new Set();
   for (const object of data) {
@@ -54701,7 +54706,7 @@ var omap = {
   }
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/pairs.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/pairs.ts
 function resolveYamlPairs(data) {
   if (data === null) return true;
   return data.every((it) => isPlainObject(it) && Object.keys(it).length === 1);
@@ -54715,7 +54720,7 @@ var pairs = {
   resolve: resolveYamlPairs
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/regexp.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/regexp.ts
 var REGEXP = /^\/(?<regexp>[\s\S]+)\/(?<modifiers>[gismuy]*)$/;
 var regexp = {
   tag: "tag:yaml.org,2002:js/regexp",
@@ -54738,7 +54743,7 @@ var regexp = {
   represent: (object) => object.toString()
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/seq.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/seq.ts
 var seq = {
   tag: "tag:yaml.org,2002:seq",
   kind: "sequence",
@@ -54746,7 +54751,7 @@ var seq = {
   construct: (data) => data !== null ? data : []
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/set.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/set.ts
 var set = {
   tag: "tag:yaml.org,2002:set",
   kind: "mapping",
@@ -54757,7 +54762,7 @@ var set = {
   }
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/str.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/str.ts
 var str = {
   tag: "tag:yaml.org,2002:str",
   kind: "scalar",
@@ -54765,7 +54770,7 @@ var str = {
   construct: (data) => data !== null ? data : ""
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/timestamp.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/timestamp.ts
 var YAML_DATE_REGEXP = new RegExp(
   "^([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])$"
   // [3] day
@@ -54830,7 +54835,7 @@ var timestamp = {
   resolve: resolveYamlTimestamp
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/undefined.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/undefined.ts
 var undefinedType = {
   tag: "tag:yaml.org,2002:js/undefined",
   kind: "scalar",
@@ -54848,7 +54853,7 @@ var undefinedType = {
   }
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.12/_schema.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.11/_schema.ts
 function createTypeMap(implicitTypes, explicitTypes) {
   const result = {
     fallback: /* @__PURE__ */ new Map(),
@@ -54899,7 +54904,7 @@ var SCHEMA_MAP = /* @__PURE__ */ new Map([
   ["extended", EXTENDED_SCHEMA]
 ]);
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.12/_loader_state.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.11/_loader_state.ts
 var CONTEXT_FLOW_IN = 1;
 var CONTEXT_FLOW_OUT = 2;
 var CONTEXT_BLOCK_IN = 3;
@@ -55028,29 +55033,12 @@ function writeFoldedLines(count) {
   if (count > 1) return "\n".repeat(count - 1);
   return "";
 }
-var Scanner = class {
-  source;
-  #length;
-  position = 0;
-  constructor(source) {
-    source += "\0";
-    this.source = source;
-    this.#length = source.length;
-  }
-  peek(offset = 0) {
-    return this.source.charCodeAt(this.position + offset);
-  }
-  next() {
-    this.position += 1;
-  }
-  eof() {
-    return this.position >= this.#length - 1;
-  }
-};
 var LoaderState = class {
-  #scanner;
+  input;
+  length;
   lineIndent = 0;
   lineStart = 0;
+  position = 0;
   line = 0;
   onWarning;
   allowDuplicateKeys;
@@ -55064,44 +55052,48 @@ var LoaderState = class {
     onWarning,
     allowDuplicateKeys = false
   }) {
-    this.#scanner = new Scanner(input);
+    this.input = input;
     this.onWarning = onWarning;
     this.allowDuplicateKeys = allowDuplicateKeys;
     this.implicitTypes = schema.implicitTypes;
     this.typeMap = schema.typeMap;
+    this.length = input.length;
     this.readIndent();
   }
   skipWhitespaces() {
-    let ch = this.#scanner.peek();
+    let ch = this.peek();
     while (isWhiteSpace(ch)) {
-      this.#scanner.next();
-      ch = this.#scanner.peek();
+      ch = this.next();
     }
   }
   skipComment() {
-    let ch = this.#scanner.peek();
+    let ch = this.peek();
     if (ch !== SHARP) return;
-    this.#scanner.next();
-    ch = this.#scanner.peek();
+    ch = this.next();
     while (ch !== 0 && !isEOL(ch)) {
-      this.#scanner.next();
-      ch = this.#scanner.peek();
+      ch = this.next();
     }
   }
   readIndent() {
-    let ch = this.#scanner.peek();
-    while (ch === SPACE) {
+    let char = this.peek();
+    while (char === SPACE) {
       this.lineIndent += 1;
-      this.#scanner.next();
-      ch = this.#scanner.peek();
+      char = this.next();
     }
+  }
+  peek(offset = 0) {
+    return this.input.charCodeAt(this.position + offset);
+  }
+  next() {
+    this.position += 1;
+    return this.peek();
   }
   #createError(message2) {
     const mark = markToString(
-      this.#scanner.source,
-      this.#scanner.position,
+      this.input,
+      this.position,
       this.line,
-      this.#scanner.position - this.lineStart
+      this.position - this.lineStart
     );
     return new SyntaxError(`${message2} ${mark}`);
   }
@@ -55163,7 +55155,7 @@ var LoaderState = class {
   }
   captureSegment(start, end, checkJson) {
     if (start < end) {
-      const result = this.#scanner.source.slice(start, end);
+      const result = this.input.slice(start, end);
       if (checkJson) {
         for (let position = 0; position < result.length; position++) {
           const character = result.charCodeAt(position);
@@ -55183,21 +55175,21 @@ var LoaderState = class {
     let detected = false;
     const result = [];
     if (anchor !== null) this.anchorMap.set(anchor, result);
-    let ch = this.#scanner.peek();
+    let ch = this.peek();
     while (ch !== 0) {
       if (ch !== MINUS) {
         break;
       }
-      const following = this.#scanner.peek(1);
+      const following = this.peek(1);
       if (!isWhiteSpaceOrEOL(following)) {
         break;
       }
       detected = true;
-      this.#scanner.next();
+      this.position++;
       if (this.skipSeparationSpace(true, -1)) {
         if (this.lineIndent <= nodeIndent) {
           result.push(null);
-          ch = this.#scanner.peek();
+          ch = this.peek();
           continue;
         }
       }
@@ -55210,7 +55202,7 @@ var LoaderState = class {
       });
       if (newState) result.push(newState.result);
       this.skipSeparationSpace(true, -1);
-      ch = this.#scanner.peek();
+      ch = this.peek();
       if ((this.line === line || this.lineIndent > nodeIndent) && ch !== 0) {
         throw this.#createError(
           "Cannot read block sequence: bad indentation of a sequence entry"
@@ -55271,7 +55263,7 @@ var LoaderState = class {
     } else {
       if (!this.allowDuplicateKeys && !overridableKeys.has(keyNode) && Object.hasOwn(result, keyNode)) {
         this.line = startLine || this.line;
-        this.#scanner.position = startPos || this.#scanner.position;
+        this.position = startPos || this.position;
         throw this.#createError("Cannot store mapping pair: duplicated key");
       }
       Object.defineProperty(result, keyNode, {
@@ -55285,37 +55277,37 @@ var LoaderState = class {
     return result;
   }
   readLineBreak() {
-    const ch = this.#scanner.peek();
+    const ch = this.peek();
     if (ch === LINE_FEED) {
-      this.#scanner.next();
+      this.position++;
     } else if (ch === CARRIAGE_RETURN) {
-      this.#scanner.next();
-      if (this.#scanner.peek() === LINE_FEED) {
-        this.#scanner.next();
+      this.position++;
+      if (this.peek() === LINE_FEED) {
+        this.position++;
       }
     } else {
       throw this.#createError("Cannot read line: line break not found");
     }
     this.line += 1;
-    this.lineStart = this.#scanner.position;
+    this.lineStart = this.position;
   }
   skipSeparationSpace(allowComments, checkIndent) {
     let lineBreaks = 0;
-    let ch = this.#scanner.peek();
+    let ch = this.peek();
     while (ch !== 0) {
       this.skipWhitespaces();
-      ch = this.#scanner.peek();
+      ch = this.peek();
       if (allowComments) {
         this.skipComment();
-        ch = this.#scanner.peek();
+        ch = this.peek();
       }
       if (isEOL(ch)) {
         this.readLineBreak();
-        ch = this.#scanner.peek();
+        ch = this.peek();
         lineBreaks++;
         this.lineIndent = 0;
         this.readIndent();
-        ch = this.#scanner.peek();
+        ch = this.peek();
       } else {
         break;
       }
@@ -55326,9 +55318,9 @@ var LoaderState = class {
     return lineBreaks;
   }
   testDocumentSeparator() {
-    let ch = this.#scanner.peek();
-    if ((ch === MINUS || ch === DOT) && ch === this.#scanner.peek(1) && ch === this.#scanner.peek(2)) {
-      ch = this.#scanner.peek(3);
+    let ch = this.peek();
+    if ((ch === MINUS || ch === DOT) && ch === this.peek(1) && ch === this.peek(2)) {
+      ch = this.peek(3);
       if (ch === 0 || isWhiteSpaceOrEOL(ch)) {
         return true;
       }
@@ -55336,34 +55328,34 @@ var LoaderState = class {
     return false;
   }
   readPlainScalar(tag, anchor, nodeIndent, withinFlowCollection) {
-    let ch = this.#scanner.peek();
+    let ch = this.peek();
     if (isWhiteSpaceOrEOL(ch) || isFlowIndicator(ch) || ch === SHARP || ch === AMPERSAND || ch === ASTERISK || ch === EXCLAMATION || ch === VERTICAL_LINE || ch === GREATER_THAN || ch === SINGLE_QUOTE || ch === DOUBLE_QUOTE || ch === PERCENT || ch === COMMERCIAL_AT || ch === GRAVE_ACCENT) {
       return;
     }
     let following;
     if (ch === QUESTION || ch === MINUS) {
-      following = this.#scanner.peek(1);
+      following = this.peek(1);
       if (isWhiteSpaceOrEOL(following) || withinFlowCollection && isFlowIndicator(following)) {
         return;
       }
     }
     let result = "";
-    let captureEnd = this.#scanner.position;
-    let captureStart = this.#scanner.position;
+    let captureEnd = this.position;
+    let captureStart = this.position;
     let hasPendingContent = false;
     let line = 0;
     while (ch !== 0) {
       if (ch === COLON) {
-        following = this.#scanner.peek(1);
+        following = this.peek(1);
         if (isWhiteSpaceOrEOL(following) || withinFlowCollection && isFlowIndicator(following)) {
           break;
         }
       } else if (ch === SHARP) {
-        const preceding = this.#scanner.peek(-1);
+        const preceding = this.peek(-1);
         if (isWhiteSpaceOrEOL(preceding)) {
           break;
         }
-      } else if (this.#scanner.position === this.lineStart && this.testDocumentSeparator() || withinFlowCollection && isFlowIndicator(ch)) {
+      } else if (this.position === this.lineStart && this.testDocumentSeparator() || withinFlowCollection && isFlowIndicator(ch)) {
         break;
       } else if (isEOL(ch)) {
         line = this.line;
@@ -55372,10 +55364,10 @@ var LoaderState = class {
         this.skipSeparationSpace(false, -1);
         if (this.lineIndent >= nodeIndent) {
           hasPendingContent = true;
-          ch = this.#scanner.peek();
+          ch = this.peek();
           continue;
         } else {
-          this.#scanner.position = captureEnd;
+          this.position = captureEnd;
           this.line = line;
           this.lineStart = lineStart;
           this.lineIndent = lineIndent;
@@ -55386,14 +55378,13 @@ var LoaderState = class {
         const segment2 = this.captureSegment(captureStart, captureEnd, false);
         if (segment2) result += segment2;
         result += writeFoldedLines(this.line - line);
-        captureStart = captureEnd = this.#scanner.position;
+        captureStart = captureEnd = this.position;
         hasPendingContent = false;
       }
       if (!isWhiteSpace(ch)) {
-        captureEnd = this.#scanner.position + 1;
+        captureEnd = this.position + 1;
       }
-      this.#scanner.next();
-      ch = this.#scanner.peek();
+      ch = this.next();
     }
     const segment = this.captureSegment(captureStart, captureEnd, false);
     if (segment) result += segment;
@@ -55401,27 +55392,22 @@ var LoaderState = class {
     if (result) return { tag, anchor, kind: "scalar", result };
   }
   readSingleQuotedScalar(tag, anchor, nodeIndent) {
-    let ch = this.#scanner.peek();
+    let ch = this.peek();
     if (ch !== SINGLE_QUOTE) return;
     let result = "";
-    this.#scanner.next();
-    let captureStart = this.#scanner.position;
-    let captureEnd = this.#scanner.position;
-    ch = this.#scanner.peek();
+    this.position++;
+    let captureStart = this.position;
+    let captureEnd = this.position;
+    ch = this.peek();
     while (ch !== 0) {
       if (ch === SINGLE_QUOTE) {
-        const segment = this.captureSegment(
-          captureStart,
-          this.#scanner.position,
-          true
-        );
+        const segment = this.captureSegment(captureStart, this.position, true);
         if (segment) result += segment;
-        this.#scanner.next();
-        ch = this.#scanner.peek();
+        ch = this.next();
         if (ch === SINGLE_QUOTE) {
-          captureStart = this.#scanner.position;
-          this.#scanner.next();
-          captureEnd = this.#scanner.position;
+          captureStart = this.position;
+          this.position++;
+          captureEnd = this.position;
         } else {
           if (anchor !== null) this.anchorMap.set(anchor, result);
           return { tag, anchor, kind: "scalar", result };
@@ -55432,62 +55418,52 @@ var LoaderState = class {
         result += writeFoldedLines(
           this.skipSeparationSpace(false, nodeIndent)
         );
-        captureStart = captureEnd = this.#scanner.position;
-      } else if (this.#scanner.position === this.lineStart && this.testDocumentSeparator()) {
+        captureStart = captureEnd = this.position;
+      } else if (this.position === this.lineStart && this.testDocumentSeparator()) {
         throw this.#createError(
           "Unexpected end of the document within a single quoted scalar"
         );
       } else {
-        this.#scanner.next();
-        captureEnd = this.#scanner.position;
+        this.position++;
+        captureEnd = this.position;
       }
-      ch = this.#scanner.peek();
+      ch = this.peek();
     }
     throw this.#createError(
       "Unexpected end of the stream within a single quoted scalar"
     );
   }
   readDoubleQuotedScalar(tag, anchor, nodeIndent) {
-    let ch = this.#scanner.peek();
+    let ch = this.peek();
     if (ch !== DOUBLE_QUOTE) return;
     let result = "";
-    this.#scanner.next();
-    let captureEnd = this.#scanner.position;
-    let captureStart = this.#scanner.position;
+    this.position++;
+    let captureEnd = this.position;
+    let captureStart = this.position;
     let tmp;
-    ch = this.#scanner.peek();
+    ch = this.peek();
     while (ch !== 0) {
       if (ch === DOUBLE_QUOTE) {
-        const segment = this.captureSegment(
-          captureStart,
-          this.#scanner.position,
-          true
-        );
+        const segment = this.captureSegment(captureStart, this.position, true);
         if (segment) result += segment;
-        this.#scanner.next();
+        this.position++;
         if (anchor !== null) this.anchorMap.set(anchor, result);
         return { tag, anchor, kind: "scalar", result };
       }
       if (ch === BACKSLASH) {
-        const segment = this.captureSegment(
-          captureStart,
-          this.#scanner.position,
-          true
-        );
+        const segment = this.captureSegment(captureStart, this.position, true);
         if (segment) result += segment;
-        this.#scanner.next();
-        ch = this.#scanner.peek();
+        ch = this.next();
         if (isEOL(ch)) {
           this.skipSeparationSpace(false, nodeIndent);
         } else if (ch < 256 && SIMPLE_ESCAPE_SEQUENCES.has(ch)) {
           result += SIMPLE_ESCAPE_SEQUENCES.get(ch);
-          this.#scanner.next();
+          this.position++;
         } else if ((tmp = ESCAPED_HEX_LENGTHS.get(ch) ?? 0) > 0) {
           let hexLength = tmp;
           let hexResult = 0;
           for (; hexLength > 0; hexLength--) {
-            this.#scanner.next();
-            ch = this.#scanner.peek();
+            ch = this.next();
             if ((tmp = hexCharCodeToNumber(ch)) >= 0) {
               hexResult = (hexResult << 4) + tmp;
             } else {
@@ -55497,36 +55473,36 @@ var LoaderState = class {
             }
           }
           result += codepointToChar(hexResult);
-          this.#scanner.next();
+          this.position++;
         } else {
           throw this.#createError(
             "Cannot read double quoted scalar: unknown escape sequence"
           );
         }
-        captureStart = captureEnd = this.#scanner.position;
+        captureStart = captureEnd = this.position;
       } else if (isEOL(ch)) {
         const segment = this.captureSegment(captureStart, captureEnd, true);
         if (segment) result += segment;
         result += writeFoldedLines(
           this.skipSeparationSpace(false, nodeIndent)
         );
-        captureStart = captureEnd = this.#scanner.position;
-      } else if (this.#scanner.position === this.lineStart && this.testDocumentSeparator()) {
+        captureStart = captureEnd = this.position;
+      } else if (this.position === this.lineStart && this.testDocumentSeparator()) {
         throw this.#createError(
           "Unexpected end of the document within a double quoted scalar"
         );
       } else {
-        this.#scanner.next();
-        captureEnd = this.#scanner.position;
+        this.position++;
+        captureEnd = this.position;
       }
-      ch = this.#scanner.peek();
+      ch = this.peek();
     }
     throw this.#createError(
       "Unexpected end of the stream within a double quoted scalar"
     );
   }
   readFlowCollection(tag, anchor, nodeIndent) {
-    let ch = this.#scanner.peek();
+    let ch = this.peek();
     let terminator;
     let isMapping = true;
     let result = {};
@@ -55540,8 +55516,7 @@ var LoaderState = class {
       return;
     }
     if (anchor !== null) this.anchorMap.set(anchor, result);
-    this.#scanner.next();
-    ch = this.#scanner.peek();
+    ch = this.next();
     let readNext = true;
     let valueNode = null;
     let keyNode = null;
@@ -55553,9 +55528,9 @@ var LoaderState = class {
     const overridableKeys = /* @__PURE__ */ new Set();
     while (ch !== 0) {
       this.skipSeparationSpace(true, nodeIndent);
-      ch = this.#scanner.peek();
+      ch = this.peek();
       if (ch === terminator) {
-        this.#scanner.next();
+        this.position++;
         const kind = isMapping ? "mapping" : "sequence";
         return { tag, anchor, kind, result };
       }
@@ -55567,10 +55542,10 @@ var LoaderState = class {
       keyTag = keyNode = valueNode = null;
       isPair = isExplicitPair = false;
       if (ch === QUESTION) {
-        following = this.#scanner.peek(1);
+        following = this.peek(1);
         if (isWhiteSpaceOrEOL(following)) {
           isPair = isExplicitPair = true;
-          this.#scanner.next();
+          this.position++;
           this.skipSeparationSpace(true, nodeIndent);
         }
       }
@@ -55586,11 +55561,10 @@ var LoaderState = class {
         keyNode = newState.result;
       }
       this.skipSeparationSpace(true, nodeIndent);
-      ch = this.#scanner.peek();
+      ch = this.peek();
       if ((isExplicitPair || this.line === line) && ch === COLON) {
         isPair = true;
-        this.#scanner.next();
-        ch = this.#scanner.peek();
+        ch = this.next();
         this.skipSeparationSpace(true, nodeIndent);
         const newState2 = this.composeNode({
           parentIndent: nodeIndent,
@@ -55622,11 +55596,10 @@ var LoaderState = class {
         result.push(keyNode);
       }
       this.skipSeparationSpace(true, nodeIndent);
-      ch = this.#scanner.peek();
+      ch = this.peek();
       if (ch === COMMA) {
         readNext = true;
-        this.#scanner.next();
-        ch = this.#scanner.peek();
+        ch = this.next();
       } else {
         readNext = false;
       }
@@ -55644,7 +55617,7 @@ var LoaderState = class {
     let textIndent = nodeIndent;
     let emptyLines = 0;
     let atMoreIndented = false;
-    let ch = this.#scanner.peek();
+    let ch = this.peek();
     let folding = false;
     if (ch === VERTICAL_LINE) {
       folding = false;
@@ -55656,8 +55629,7 @@ var LoaderState = class {
     let result = "";
     let tmp = 0;
     while (ch !== 0) {
-      this.#scanner.next();
-      ch = this.#scanner.peek();
+      ch = this.next();
       if (ch === PLUS || ch === MINUS) {
         if (CHOMPING_CLIP === chomping) {
           chomping = ch === PLUS ? CHOMPING_KEEP : CHOMPING_STRIP;
@@ -55686,16 +55658,15 @@ var LoaderState = class {
     if (isWhiteSpace(ch)) {
       this.skipWhitespaces();
       this.skipComment();
-      ch = this.#scanner.peek();
+      ch = this.peek();
     }
     while (ch !== 0) {
       this.readLineBreak();
       this.lineIndent = 0;
-      ch = this.#scanner.peek();
+      ch = this.peek();
       while ((!detectedIndent || this.lineIndent < textIndent) && ch === SPACE) {
         this.lineIndent++;
-        this.#scanner.next();
-        ch = this.#scanner.peek();
+        ch = this.next();
       }
       if (!detectedIndent && this.lineIndent > textIndent) {
         textIndent = this.lineIndent;
@@ -55740,16 +55711,11 @@ var LoaderState = class {
       didReadContent = true;
       detectedIndent = true;
       emptyLines = 0;
-      const captureStart = this.#scanner.position;
+      const captureStart = this.position;
       while (!isEOL(ch) && ch !== 0) {
-        this.#scanner.next();
-        ch = this.#scanner.peek();
+        ch = this.next();
       }
-      const segment = this.captureSegment(
-        captureStart,
-        this.#scanner.position,
-        false
-      );
+      const segment = this.captureSegment(captureStart, this.position, false);
       if (segment) result += segment;
     }
     if (anchor !== null) this.anchorMap.set(anchor, result);
@@ -55767,11 +55733,11 @@ var LoaderState = class {
     let atExplicitKey = false;
     let detected = false;
     if (anchor !== null) this.anchorMap.set(anchor, result);
-    let ch = this.#scanner.peek();
+    let ch = this.peek();
     while (ch !== 0) {
-      const following = this.#scanner.peek(1);
+      const following = this.peek(1);
       line = this.line;
-      pos = this.#scanner.position;
+      pos = this.position;
       if ((ch === QUESTION || ch === COLON) && isWhiteSpaceOrEOL(following)) {
         if (ch === QUESTION) {
           if (atExplicitKey) {
@@ -55797,7 +55763,7 @@ var LoaderState = class {
             "Cannot read block as explicit mapping pair is incomplete: a key node is missed or followed by a non-tabulated empty line"
           );
         }
-        this.#scanner.next();
+        this.position += 1;
         ch = following;
       } else {
         const newState = this.composeNode({
@@ -55808,12 +55774,11 @@ var LoaderState = class {
         });
         if (!newState) break;
         if (this.line === line) {
-          ch = this.#scanner.peek();
+          ch = this.peek();
           this.skipWhitespaces();
-          ch = this.#scanner.peek();
+          ch = this.peek();
           if (ch === COLON) {
-            this.#scanner.next();
-            ch = this.#scanner.peek();
+            ch = this.next();
             if (!isWhiteSpaceOrEOL(ch)) {
               throw this.#createError(
                 "Cannot read block: a whitespace character is expected after the key-value separator within a block mapping"
@@ -55880,7 +55845,7 @@ var LoaderState = class {
           keyTag = keyNode = valueNode = null;
         }
         this.skipSeparationSpace(true, -1);
-        ch = this.#scanner.peek();
+        ch = this.peek();
       }
       if (this.lineIndent > nodeIndent && ch !== 0) {
         throw this.#createError(
@@ -55906,37 +55871,32 @@ var LoaderState = class {
     let isNamed = false;
     let tagHandle = "";
     let tagName;
-    let ch = this.#scanner.peek();
+    let ch = this.peek();
     if (ch !== EXCLAMATION) return;
     if (tag !== null) {
       throw this.#createError(
         "Cannot read tag property: duplication of a tag property"
       );
     }
-    this.#scanner.next();
-    ch = this.#scanner.peek();
+    ch = this.next();
     if (ch === SMALLER_THAN) {
       isVerbatim = true;
-      this.#scanner.next();
-      ch = this.#scanner.peek();
+      ch = this.next();
     } else if (ch === EXCLAMATION) {
       isNamed = true;
       tagHandle = "!!";
-      this.#scanner.next();
-      ch = this.#scanner.peek();
+      ch = this.next();
     } else {
       tagHandle = "!";
     }
-    let position = this.#scanner.position;
+    let position = this.position;
     if (isVerbatim) {
       do {
-        this.#scanner.next();
-        ch = this.#scanner.peek();
+        ch = this.next();
       } while (ch !== 0 && ch !== GREATER_THAN);
-      if (!this.#scanner.eof()) {
-        tagName = this.#scanner.source.slice(position, this.#scanner.position);
-        this.#scanner.next();
-        ch = this.#scanner.peek();
+      if (this.position < this.length) {
+        tagName = this.input.slice(position, this.position);
+        ch = this.next();
       } else {
         throw this.#createError(
           "Cannot read tag property: unexpected end of stream"
@@ -55946,27 +55906,23 @@ var LoaderState = class {
       while (ch !== 0 && !isWhiteSpaceOrEOL(ch)) {
         if (ch === EXCLAMATION) {
           if (!isNamed) {
-            tagHandle = this.#scanner.source.slice(
-              position - 1,
-              this.#scanner.position + 1
-            );
+            tagHandle = this.input.slice(position - 1, this.position + 1);
             if (!PATTERN_TAG_HANDLE.test(tagHandle)) {
               throw this.#createError(
                 "Cannot read tag property: named tag handle contains invalid characters"
               );
             }
             isNamed = true;
-            position = this.#scanner.position + 1;
+            position = this.position + 1;
           } else {
             throw this.#createError(
               "Cannot read tag property: tag suffix cannot contain an exclamation mark"
             );
           }
         }
-        this.#scanner.next();
-        ch = this.#scanner.peek();
+        ch = this.next();
       }
-      tagName = this.#scanner.source.slice(position, this.#scanner.position);
+      tagName = this.input.slice(position, this.position);
       if (PATTERN_FLOW_INDICATORS.test(tagName)) {
         throw this.#createError(
           "Cannot read tag property: tag suffix cannot contain flow indicator characters"
@@ -55992,42 +55948,38 @@ var LoaderState = class {
     );
   }
   readAnchorProperty(anchor) {
-    let ch = this.#scanner.peek();
+    let ch = this.peek();
     if (ch !== AMPERSAND) return;
     if (anchor !== null) {
       throw this.#createError(
         "Cannot read anchor property: duplicate anchor property"
       );
     }
-    this.#scanner.next();
-    ch = this.#scanner.peek();
-    const position = this.#scanner.position;
+    ch = this.next();
+    const position = this.position;
     while (ch !== 0 && !isWhiteSpaceOrEOL(ch) && !isFlowIndicator(ch)) {
-      this.#scanner.next();
-      ch = this.#scanner.peek();
+      ch = this.next();
     }
-    if (this.#scanner.position === position) {
+    if (this.position === position) {
       throw this.#createError(
         "Cannot read anchor property: name of an anchor node must contain at least one character"
       );
     }
-    return this.#scanner.source.slice(position, this.#scanner.position);
+    return this.input.slice(position, this.position);
   }
   readAlias() {
-    if (this.#scanner.peek() !== ASTERISK) return;
-    this.#scanner.next();
-    let ch = this.#scanner.peek();
-    const position = this.#scanner.position;
+    if (this.peek() !== ASTERISK) return;
+    let ch = this.next();
+    const position = this.position;
     while (ch !== 0 && !isWhiteSpaceOrEOL(ch) && !isFlowIndicator(ch)) {
-      this.#scanner.next();
-      ch = this.#scanner.peek();
+      ch = this.next();
     }
-    if (this.#scanner.position === position) {
+    if (this.position === position) {
       throw this.#createError(
         "Cannot read alias: alias name must contain at least one character"
       );
     }
-    const alias = this.#scanner.source.slice(position, this.#scanner.position);
+    const alias = this.input.slice(position, this.position);
     if (!this.anchorMap.has(alias)) {
       throw this.#createError(
         `Cannot read alias: unidentified alias "${alias}"`
@@ -56118,7 +56070,7 @@ var LoaderState = class {
       const cond = CONTEXT_FLOW_IN === nodeContext || CONTEXT_FLOW_OUT === nodeContext;
       const flowIndent = cond ? parentIndent : parentIndent + 1;
       if (allowBlockCollections) {
-        const blockIndent = this.#scanner.position - this.lineStart;
+        const blockIndent = this.position - this.lineStart;
         const blockSequenceState = this.readBlockSequence(
           tag,
           anchor,
@@ -56179,7 +56131,7 @@ var LoaderState = class {
         return this.resolveTag(plainScalarState);
       }
     } else if (indentStatus === 0 && CONTEXT_BLOCK_OUT === nodeContext && allowBlockCollections) {
-      const blockIndent = this.#scanner.position - this.lineStart;
+      const blockIndent = this.position - this.lineStart;
       const newState2 = this.readBlockSequence(tag, anchor, blockIndent);
       if (newState2) return this.resolveTag(newState2);
     }
@@ -56189,25 +56141,20 @@ var LoaderState = class {
   readDirectives() {
     let hasDirectives = false;
     let version = null;
-    let ch = this.#scanner.peek();
+    let ch = this.peek();
     while (ch !== 0) {
       this.skipSeparationSpace(true, -1);
-      ch = this.#scanner.peek();
+      ch = this.peek();
       if (this.lineIndent > 0 || ch !== PERCENT) {
         break;
       }
       hasDirectives = true;
-      this.#scanner.next();
-      ch = this.#scanner.peek();
-      let position = this.#scanner.position;
+      ch = this.next();
+      let position = this.position;
       while (ch !== 0 && !isWhiteSpaceOrEOL(ch)) {
-        this.#scanner.next();
-        ch = this.#scanner.peek();
+        ch = this.next();
       }
-      const directiveName = this.#scanner.source.slice(
-        position,
-        this.#scanner.position
-      );
+      const directiveName = this.input.slice(position, this.position);
       const directiveArgs = [];
       if (directiveName.length < 1) {
         throw this.#createError(
@@ -56217,16 +56164,13 @@ var LoaderState = class {
       while (ch !== 0) {
         this.skipWhitespaces();
         this.skipComment();
-        ch = this.#scanner.peek();
+        ch = this.peek();
         if (isEOL(ch)) break;
-        position = this.#scanner.position;
+        position = this.position;
         while (ch !== 0 && !isWhiteSpaceOrEOL(ch)) {
-          this.#scanner.next();
-          ch = this.#scanner.peek();
+          ch = this.next();
         }
-        directiveArgs.push(
-          this.#scanner.source.slice(position, this.#scanner.position)
-        );
+        directiveArgs.push(this.input.slice(position, this.position));
       }
       if (ch !== 0) this.readLineBreak();
       switch (directiveName) {
@@ -56245,20 +56189,20 @@ var LoaderState = class {
           this.dispatchWarning(`unknown document directive "${directiveName}"`);
           break;
       }
-      ch = this.#scanner.peek();
+      ch = this.peek();
     }
     return hasDirectives;
   }
   readDocument() {
-    const documentStart = this.#scanner.position;
+    const documentStart = this.position;
     this.checkLineBreaks = false;
     this.tagMap = /* @__PURE__ */ new Map();
     this.anchorMap = /* @__PURE__ */ new Map();
     const hasDirectives = this.readDirectives();
     this.skipSeparationSpace(true, -1);
     let result = null;
-    if (this.lineIndent === 0 && this.#scanner.peek() === MINUS && this.#scanner.peek(1) === MINUS && this.#scanner.peek(2) === MINUS) {
-      this.#scanner.position += 3;
+    if (this.lineIndent === 0 && this.peek() === MINUS && this.peek(1) === MINUS && this.peek(2) === MINUS) {
+      this.position += 3;
       this.skipSeparationSpace(true, -1);
     } else if (hasDirectives) {
       throw this.#createError(
@@ -56274,16 +56218,16 @@ var LoaderState = class {
     if (newState) result = newState.result;
     this.skipSeparationSpace(true, -1);
     if (this.checkLineBreaks && PATTERN_NON_ASCII_LINE_BREAKS.test(
-      this.#scanner.source.slice(documentStart, this.#scanner.position)
+      this.input.slice(documentStart, this.position)
     )) {
       this.dispatchWarning("non-ASCII line breaks are interpreted as content");
     }
-    if (this.#scanner.position === this.lineStart && this.testDocumentSeparator()) {
-      if (this.#scanner.peek() === DOT) {
-        this.#scanner.position += 3;
+    if (this.position === this.lineStart && this.testDocumentSeparator()) {
+      if (this.peek() === DOT) {
+        this.position += 3;
         this.skipSeparationSpace(true, -1);
       }
-    } else if (!this.#scanner.eof()) {
+    } else if (this.position < this.length - 1) {
       throw this.#createError(
         "Cannot read document: end of the stream or a document separator is expected"
       );
@@ -56291,19 +56235,20 @@ var LoaderState = class {
     return result;
   }
   *readDocuments() {
-    while (!this.#scanner.eof()) {
+    while (this.position < this.length - 1) {
       yield this.readDocument();
     }
   }
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.12/parse.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.11/parse.ts
 function sanitizeInput(input) {
   input = String(input);
   if (input.length > 0) {
     if (!isEOL(input.charCodeAt(input.length - 1))) input += "\n";
     if (input.charCodeAt(0) === 65279) input = input.slice(1);
   }
+  input += "\0";
   return input;
 }
 function parse(content, options = {}) {
@@ -61889,6 +61834,49 @@ function extractSubSteps(logBlocks, compositeStartedAt, compositeCompletedAt, co
     };
   });
 }
+function expandJobSteps(steps, compositeInfos, compositeStepCounts, logBlocks) {
+  const compositeInfoByIndex = new Map(
+    compositeInfos.map((info2) => [info2.apiStepIndex, info2])
+  );
+  const newSteps = [];
+  for (let i = 0; i < steps.length; i++) {
+    const compositeInfo = compositeInfoByIndex.get(i);
+    if (!compositeInfo || !compositeStepCounts.has(compositeInfo.usesPath)) {
+      newSteps.push(steps[i]);
+      continue;
+    }
+    const apiStep = steps[i];
+    if (!apiStep.started_at || !apiStep.completed_at) {
+      newSteps.push(apiStep);
+      continue;
+    }
+    const expectedStepCount = compositeStepCounts.get(compositeInfo.usesPath);
+    const subSteps = extractSubSteps(
+      logBlocks,
+      apiStep.started_at,
+      apiStep.completed_at,
+      apiStep.status,
+      apiStep.conclusion,
+      compositeInfo.usesPath,
+      expectedStepCount
+    );
+    newSteps.push(apiStep);
+    if (subSteps.length === 0) {
+      continue;
+    }
+    subSteps.forEach((subStep) => {
+      newSteps.push({
+        ...apiStep,
+        name: `(sub) ${subStep.name}`,
+        started_at: subStep.started_at,
+        completed_at: subStep.completed_at,
+        number: apiStep.number,
+        timelineRowKind: "composite-child"
+      });
+    });
+  }
+  return newSteps;
+}
 async function expandCompositeSteps(client, workflowRun, workflowJobs, options = {}) {
   const thresholdSec = options.thresholdSec ?? 20;
   const workflowModel = await fetchWorkflowModel(client, workflowRun);
@@ -61946,48 +61934,15 @@ async function expandCompositeSteps(client, workflowRun, workflowJobs, options =
     if (!logText) return job;
     const logBlocks = parseLogBlocks(logText);
     if (logBlocks.length === 0) return job;
-    const compositeInfoByIndex = new Map(
-      compositeInfos.map((info2) => [info2.apiStepIndex, info2])
-    );
-    const newSteps = [];
-    for (let i = 0; i < job.steps.length; i++) {
-      const compositeInfo = compositeInfoByIndex.get(i);
-      if (!compositeInfo || !compositeStepCounts.has(compositeInfo.usesPath)) {
-        newSteps.push(job.steps[i]);
-        continue;
-      }
-      const apiStep = job.steps[i];
-      if (!apiStep.started_at || !apiStep.completed_at) {
-        newSteps.push(apiStep);
-        continue;
-      }
-      const expectedStepCount = compositeStepCounts.get(
-        compositeInfo.usesPath
-      );
-      const subSteps = extractSubSteps(
-        logBlocks,
-        apiStep.started_at,
-        apiStep.completed_at,
-        apiStep.status,
-        apiStep.conclusion,
-        compositeInfo.usesPath,
-        expectedStepCount
-      );
-      if (subSteps.length === 0) {
-        newSteps.push(apiStep);
-        continue;
-      }
-      for (const subStep of subSteps) {
-        newSteps.push({
-          ...apiStep,
-          name: `(sub) ${subStep.name}`,
-          started_at: subStep.started_at,
-          completed_at: subStep.completed_at,
-          number: apiStep.number
-        });
-      }
-    }
-    return { ...job, steps: newSteps };
+    return {
+      ...job,
+      steps: expandJobSteps(
+        job.steps,
+        compositeInfos,
+        compositeStepCounts,
+        logBlocks
+      )
+    };
   });
   return expandedJobs;
 }

--- a/dist/post.js
+++ b/dist/post.js
@@ -2321,13 +2321,20 @@ var require_dispatcher_base = __commonJS({
     var kOnDestroyed = /* @__PURE__ */ Symbol("onDestroyed");
     var kOnClosed = /* @__PURE__ */ Symbol("onClosed");
     var kInterceptedDispatch = /* @__PURE__ */ Symbol("Intercepted Dispatch");
+    var kWebSocketOptions = /* @__PURE__ */ Symbol("webSocketOptions");
     var DispatcherBase = class extends Dispatcher {
-      constructor() {
+      constructor(opts) {
         super();
         this[kDestroyed] = false;
         this[kOnDestroyed] = null;
         this[kClosed] = false;
         this[kOnClosed] = [];
+        this[kWebSocketOptions] = opts?.webSocket ?? {};
+      }
+      get webSocketOptions() {
+        return {
+          maxPayloadSize: this[kWebSocketOptions].maxPayloadSize ?? 128 * 1024 * 1024
+        };
       }
       get destroyed() {
         return this[kDestroyed];
@@ -7766,9 +7773,10 @@ var require_client = __commonJS({
         autoSelectFamilyAttemptTimeout,
         // h2
         maxConcurrentStreams,
-        allowH2
+        allowH2,
+        webSocket
       } = {}) {
-        super();
+        super({ webSocket });
         if (keepAlive !== void 0) {
           throw new InvalidArgumentError("unsupported keepAlive, use pipelining=0 instead");
         }
@@ -8274,8 +8282,8 @@ var require_pool_base = __commonJS({
     var kRemoveClient = /* @__PURE__ */ Symbol("remove client");
     var kStats = /* @__PURE__ */ Symbol("stats");
     var PoolBase = class extends DispatcherBase {
-      constructor() {
-        super();
+      constructor(opts) {
+        super(opts);
         this[kQueue] = new FixedQueue();
         this[kClients] = [];
         this[kQueued] = 0;
@@ -8446,7 +8454,6 @@ var require_pool = __commonJS({
         allowH2,
         ...options
       } = {}) {
-        super();
         if (connections != null && (!Number.isFinite(connections) || connections < 0)) {
           throw new InvalidArgumentError("invalid connections");
         }
@@ -8467,6 +8474,7 @@ var require_pool = __commonJS({
             ...connect
           });
         }
+        super(options);
         this[kInterceptors] = options.interceptors?.Pool && Array.isArray(options.interceptors.Pool) ? options.interceptors.Pool : [];
         this[kConnections] = connections || null;
         this[kUrl] = util.parseOrigin(origin);
@@ -8666,7 +8674,6 @@ var require_agent = __commonJS({
     }
     var Agent = class extends DispatcherBase {
       constructor({ factory = defaultFactory, maxRedirections = 0, connect, ...options } = {}) {
-        super();
         if (typeof factory !== "function") {
           throw new InvalidArgumentError("factory must be a function.");
         }
@@ -8676,6 +8683,7 @@ var require_agent = __commonJS({
         if (!Number.isInteger(maxRedirections) || maxRedirections < 0) {
           throw new InvalidArgumentError("maxRedirections must be a positive number");
         }
+        super(options);
         if (connect && typeof connect !== "function") {
           connect = { ...connect };
         }
@@ -17309,27 +17317,26 @@ var require_permessage_deflate = __commonJS({
     var tail = Buffer.from([0, 0, 255, 255]);
     var kBuffer = /* @__PURE__ */ Symbol("kBuffer");
     var kLength = /* @__PURE__ */ Symbol("kLength");
-    var kDefaultMaxDecompressedSize = 4 * 1024 * 1024;
     var PerMessageDeflate = class {
       /** @type {import('node:zlib').InflateRaw} */
       #inflate;
       #options = {};
-      /** @type {boolean} */
-      #aborted = false;
-      /** @type {Function|null} */
-      #currentCallback = null;
+      #maxPayloadSize = 0;
       /**
        * @param {Map<string, string>} extensions
        */
-      constructor(extensions) {
+      constructor(extensions, options) {
         this.#options.serverNoContextTakeover = extensions.has("server_no_context_takeover");
         this.#options.serverMaxWindowBits = extensions.get("server_max_window_bits");
+        this.#maxPayloadSize = options.maxPayloadSize;
       }
+      /**
+       * Decompress a compressed payload.
+       * @param {Buffer} chunk Compressed data
+       * @param {boolean} fin Final fragment flag
+       * @param {Function} callback Callback function
+       */
       decompress(chunk2, fin, callback) {
-        if (this.#aborted) {
-          callback(new MessageSizeExceededError());
-          return;
-        }
         if (!this.#inflate) {
           let windowBits = Z_DEFAULT_WINDOWBITS;
           if (this.#options.serverMaxWindowBits) {
@@ -17348,20 +17355,11 @@ var require_permessage_deflate = __commonJS({
           this.#inflate[kBuffer] = [];
           this.#inflate[kLength] = 0;
           this.#inflate.on("data", (data) => {
-            if (this.#aborted) {
-              return;
-            }
             this.#inflate[kLength] += data.length;
-            if (this.#inflate[kLength] > kDefaultMaxDecompressedSize) {
-              this.#aborted = true;
+            if (this.#maxPayloadSize > 0 && this.#inflate[kLength] > this.#maxPayloadSize) {
+              callback(new MessageSizeExceededError());
               this.#inflate.removeAllListeners();
-              this.#inflate.destroy();
               this.#inflate = null;
-              if (this.#currentCallback) {
-                const cb = this.#currentCallback;
-                this.#currentCallback = null;
-                cb(new MessageSizeExceededError());
-              }
               return;
             }
             this.#inflate[kBuffer].push(data);
@@ -17371,19 +17369,17 @@ var require_permessage_deflate = __commonJS({
             callback(err);
           });
         }
-        this.#currentCallback = callback;
         this.#inflate.write(chunk2);
         if (fin) {
           this.#inflate.write(tail);
         }
         this.#inflate.flush(() => {
-          if (this.#aborted || !this.#inflate) {
+          if (!this.#inflate) {
             return;
           }
           const full = Buffer.concat(this.#inflate[kBuffer], this.#inflate[kLength]);
           this.#inflate[kBuffer].length = 0;
           this.#inflate[kLength] = 0;
-          this.#currentCallback = null;
           callback(null, full);
         });
       }
@@ -17414,8 +17410,10 @@ var require_receiver = __commonJS({
     var { WebsocketFrameSend } = require_frame();
     var { closeWebSocketConnection } = require_connection();
     var { PerMessageDeflate } = require_permessage_deflate();
+    var { MessageSizeExceededError } = require_errors();
     var ByteParser = class extends Writable {
       #buffers = [];
+      #fragmentsBytes = 0;
       #byteOffset = 0;
       #loop = false;
       #state = parserStates.INFO;
@@ -17423,16 +17421,20 @@ var require_receiver = __commonJS({
       #fragments = [];
       /** @type {Map<string, PerMessageDeflate>} */
       #extensions;
+      /** @type {number} */
+      #maxPayloadSize;
       /**
        * @param {import('./websocket').WebSocket} ws
        * @param {Map<string, string>|null} extensions
+       * @param {{ maxPayloadSize?: number }} [options]
        */
-      constructor(ws, extensions) {
+      constructor(ws, extensions, options = {}) {
         super();
         this.ws = ws;
         this.#extensions = extensions == null ? /* @__PURE__ */ new Map() : extensions;
+        this.#maxPayloadSize = options.maxPayloadSize ?? 0;
         if (this.#extensions.has("permessage-deflate")) {
-          this.#extensions.set("permessage-deflate", new PerMessageDeflate(extensions));
+          this.#extensions.set("permessage-deflate", new PerMessageDeflate(extensions, options));
         }
       }
       /**
@@ -17444,6 +17446,13 @@ var require_receiver = __commonJS({
         this.#byteOffset += chunk2.length;
         this.#loop = true;
         this.run(callback);
+      }
+      #validatePayloadLength() {
+        if (this.#maxPayloadSize > 0 && !isControlFrame(this.#info.opcode) && this.#info.payloadLength > this.#maxPayloadSize) {
+          failWebsocketConnection(this.ws, "Payload size exceeds maximum allowed size");
+          return false;
+        }
+        return true;
       }
       /**
        * Runs whenever a new chunk is received.
@@ -17504,6 +17513,9 @@ var require_receiver = __commonJS({
             if (payloadLength <= 125) {
               this.#info.payloadLength = payloadLength;
               this.#state = parserStates.READ_DATA;
+              if (!this.#validatePayloadLength()) {
+                return;
+              }
             } else if (payloadLength === 126) {
               this.#state = parserStates.PAYLOADLENGTH_16;
             } else if (payloadLength === 127) {
@@ -17524,6 +17536,9 @@ var require_receiver = __commonJS({
             const buffer = this.consume(2);
             this.#info.payloadLength = buffer.readUInt16BE(0);
             this.#state = parserStates.READ_DATA;
+            if (!this.#validatePayloadLength()) {
+              return;
+            }
           } else if (this.#state === parserStates.PAYLOADLENGTH_64) {
             if (this.#byteOffset < 8) {
               return callback();
@@ -17537,6 +17552,9 @@ var require_receiver = __commonJS({
             }
             this.#info.payloadLength = lower;
             this.#state = parserStates.READ_DATA;
+            if (!this.#validatePayloadLength()) {
+              return;
+            }
           } else if (this.#state === parserStates.READ_DATA) {
             if (this.#byteOffset < this.#info.payloadLength) {
               return callback();
@@ -17547,32 +17565,41 @@ var require_receiver = __commonJS({
               this.#state = parserStates.INFO;
             } else {
               if (!this.#info.compressed) {
-                this.#fragments.push(body);
+                this.writeFragments(body);
+                if (this.#maxPayloadSize > 0 && this.#fragmentsBytes > this.#maxPayloadSize) {
+                  failWebsocketConnection(this.ws, new MessageSizeExceededError().message);
+                  return;
+                }
                 if (!this.#info.fragmented && this.#info.fin) {
-                  const fullMessage = Buffer.concat(this.#fragments);
-                  websocketMessageReceived(this.ws, this.#info.binaryType, fullMessage);
-                  this.#fragments.length = 0;
+                  websocketMessageReceived(this.ws, this.#info.binaryType, this.consumeFragments());
                 }
                 this.#state = parserStates.INFO;
               } else {
-                this.#extensions.get("permessage-deflate").decompress(body, this.#info.fin, (error, data) => {
-                  if (error) {
-                    failWebsocketConnection(this.ws, error.message);
-                    return;
-                  }
-                  this.#fragments.push(data);
-                  if (!this.#info.fin) {
-                    this.#state = parserStates.INFO;
+                this.#extensions.get("permessage-deflate").decompress(
+                  body,
+                  this.#info.fin,
+                  (error, data) => {
+                    if (error) {
+                      failWebsocketConnection(this.ws, error.message);
+                      return;
+                    }
+                    this.writeFragments(data);
+                    if (this.#maxPayloadSize > 0 && this.#fragmentsBytes > this.#maxPayloadSize) {
+                      failWebsocketConnection(this.ws, new MessageSizeExceededError().message);
+                      return;
+                    }
+                    if (!this.#info.fin) {
+                      this.#state = parserStates.INFO;
+                      this.#loop = true;
+                      this.run(callback);
+                      return;
+                    }
+                    websocketMessageReceived(this.ws, this.#info.binaryType, this.consumeFragments());
                     this.#loop = true;
+                    this.#state = parserStates.INFO;
                     this.run(callback);
-                    return;
                   }
-                  websocketMessageReceived(this.ws, this.#info.binaryType, Buffer.concat(this.#fragments));
-                  this.#loop = true;
-                  this.#state = parserStates.INFO;
-                  this.#fragments.length = 0;
-                  this.run(callback);
-                });
+                );
                 this.#loop = false;
                 break;
               }
@@ -17614,6 +17641,21 @@ var require_receiver = __commonJS({
         }
         this.#byteOffset -= n;
         return buffer;
+      }
+      writeFragments(fragment) {
+        this.#fragmentsBytes += fragment.length;
+        this.#fragments.push(fragment);
+      }
+      consumeFragments() {
+        const fragments = this.#fragments;
+        if (fragments.length === 1) {
+          this.#fragmentsBytes = 0;
+          return fragments.shift();
+        }
+        const output = Buffer.concat(fragments, this.#fragmentsBytes);
+        this.#fragments = [];
+        this.#fragmentsBytes = 0;
+        return output;
       }
       parseCloseBody(data) {
         assert(data.length !== 1);
@@ -18052,7 +18094,10 @@ var require_websocket = __commonJS({
        */
       #onConnectionEstablished(response, parsedExtensions) {
         this[kResponse] = response;
-        const parser = new ByteParser(this, parsedExtensions);
+        const maxPayloadSize = this[kController]?.dispatcher?.webSocketOptions?.maxPayloadSize;
+        const parser = new ByteParser(this, parsedExtensions, {
+          maxPayloadSize
+        });
         parser.on("drain", onParserDrain);
         parser.on("error", onParserError.bind(this));
         response.socket.ws = this;
@@ -52333,7 +52378,7 @@ var import_node_process = __toESM(require("node:process"));
 var import_core2 = __toESM(require_core());
 var github = __toESM(require_github());
 
-// npm/src/deps/jsr.io/@std/collections/1.1.3/chunk.ts
+// npm/src/deps/jsr.io/@std/collections/1.1.6/chunk.ts
 function chunk(iterable, size) {
   if (size <= 0 || !Number.isInteger(size)) {
     throw new RangeError(
@@ -52363,23 +52408,7 @@ function chunk(iterable, size) {
   return result;
 }
 
-// npm/src/deps/jsr.io/@std/collections/1.1.3/min_of.ts
-function minOf(array, selector) {
-  let minimumValue;
-  for (const element of array) {
-    const currentValue = selector(element);
-    if (minimumValue === void 0 || currentValue < minimumValue) {
-      minimumValue = currentValue;
-      continue;
-    }
-    if (Number.isNaN(currentValue)) {
-      return currentValue;
-    }
-  }
-  return minimumValue;
-}
-
-// npm/src/deps/jsr.io/@std/collections/1.1.3/sum_of.ts
+// npm/src/deps/jsr.io/@std/collections/1.1.6/sum_of.ts
 function sumOf(array, selector) {
   let sum = 0;
   for (const i of array) {
@@ -52388,13 +52417,23 @@ function sumOf(array, selector) {
   return sum;
 }
 
-// npm/src/deps/jsr.io/@std/collections/1.1.3/zip.ts
+// npm/src/deps/jsr.io/@std/collections/1.1.6/zip.ts
 function zip(...arrays) {
-  const minLength = minOf(arrays, (element) => element.length) ?? 0;
+  const { length } = arrays;
+  if (length === 0) return [];
+  let minLength = arrays[0].length;
+  for (let i = 1; i < length; ++i) {
+    if (arrays[i].length < minLength) {
+      minLength = arrays[i].length;
+    }
+  }
   const result = new Array(minLength);
-  for (let i = 0; i < minLength; i += 1) {
-    const arr = arrays.map((it) => it[i]);
-    result[i] = arr;
+  for (let i = 0; i < minLength; ++i) {
+    const tuple = new Array(length);
+    for (let j = 0; j < length; ++j) {
+      tuple[j] = arrays[j][i];
+    }
+    result[i] = tuple;
   }
   return result;
 }
@@ -54042,6 +54081,7 @@ var convertStepToStatus = (conclusion) => {
 
 // npm/src/workflow_gantt.ts
 var MERMAID_MAX_CHAR = 5e4;
+var isString = (value) => typeof value === "string";
 var createGanttStepId = (jobIndex, stepIndex) => `job${jobIndex}-${stepIndex}`;
 var filterSteps = (steps) => {
   return steps.filter((step) => step.status === "completed");
@@ -54064,7 +54104,7 @@ var createCompositeChildPosition = (workflow, step, compositeChildAnchorId, prev
 };
 var createWaitingRunnerStep = (workflow, job, jobIndex) => {
   const status = "active";
-  if (job.created_at === void 0) {
+  if (!isString(job.created_at) || !isString(job.started_at)) {
     return void 0;
   } else {
     const startJobElapsedSec = diffSec(
@@ -54084,8 +54124,12 @@ var createWaitingRunnerStep = (workflow, job, jobIndex) => {
 var createGanttJobs = (workflow, workflowJobs, showWaitingRunner = true) => {
   return filterJobs(workflowJobs).map(
     (job, jobIndex, _jobs) => {
-      if (job.steps === void 0) return void 0;
-      const section = escapeName(job.name);
+      if (job.steps === void 0 || !isString(job.name) || !isString(job.started_at)) {
+        return void 0;
+      }
+      const jobName = job.name;
+      const jobStartedAt = job.started_at;
+      const section = escapeName(jobName);
       const completedSteps = filterSteps(job.steps);
       if (completedSteps.length === 0) return void 0;
       const steps = [];
@@ -54112,7 +54156,7 @@ var createGanttJobs = (workflow, workflowJobs, showWaitingRunner = true) => {
           previousCompositeChildId
         ) : createTopLevelStepPosition(
           workflow,
-          job.started_at,
+          jobStartedAt,
           previousTopLevelStepId
         );
         steps.push({
@@ -54295,7 +54339,7 @@ var AB = new ArrayBuffer(8);
 var U32_VIEW = new Uint32Array(AB);
 var U64_VIEW = new BigUint64Array(AB);
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.11/_chars.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.12/_chars.ts
 var TAB = 9;
 var LINE_FEED = 10;
 var CARRIAGE_RETURN = 13;
@@ -54336,7 +54380,7 @@ function isFlowIndicator(c) {
   return c === COMMA || c === LEFT_SQUARE_BRACKET || c === RIGHT_SQUARE_BRACKET || c === LEFT_CURLY_BRACKET || c === RIGHT_CURLY_BRACKET;
 }
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/binary.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/binary.ts
 var BASE64_MAP = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=\n\r";
 function resolveYamlBinary(data) {
   if (data === null) return false;
@@ -54424,7 +54468,7 @@ var binary = {
   resolve: resolveYamlBinary
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/bool.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/bool.ts
 var YAML_TRUE_BOOLEANS = ["true", "True", "TRUE"];
 var YAML_FALSE_BOOLEANS = ["false", "False", "FALSE"];
 var YAML_BOOLEANS = [...YAML_TRUE_BOOLEANS, ...YAML_FALSE_BOOLEANS];
@@ -54454,7 +54498,7 @@ var bool = {
   }
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.11/_utils.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.12/_utils.ts
 function isObject(value) {
   return value !== null && typeof value === "object";
 }
@@ -54465,7 +54509,7 @@ function isPlainObject(object) {
   return Object.prototype.toString.call(object) === "[object Object]";
 }
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/float.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/float.ts
 var YAML_FLOAT_PATTERN = new RegExp(
   // 2.5e4, 2.5 and integers
   "^(?:[-+]?(?:0|[1-9][0-9_]*)(?:\\.[0-9_]*)?(?:[eE][-+]?[0-9]+)?|\\.[0-9_]+(?:[eE][-+]?[0-9]+)?|[-+]?\\.(?:inf|Inf|INF)|\\.(?:nan|NaN|NAN))$"
@@ -54542,7 +54586,7 @@ var float = {
   resolve: resolveYamlFloat
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/int.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/int.ts
 function isCharCodeInRange(c, lower, upper) {
   return lower <= c && c <= upper;
 }
@@ -54664,7 +54708,7 @@ var int = {
   resolve: resolveYamlInteger
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/map.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/map.ts
 var map = {
   tag: "tag:yaml.org,2002:map",
   resolve() {
@@ -54676,7 +54720,7 @@ var map = {
   kind: "mapping"
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/merge.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/merge.ts
 var merge = {
   tag: "tag:yaml.org,2002:merge",
   kind: "scalar",
@@ -54684,7 +54728,7 @@ var merge = {
   construct: (data) => data
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/nil.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/nil.ts
 var nil = {
   tag: "tag:yaml.org,2002:null",
   kind: "scalar",
@@ -54701,7 +54745,7 @@ var nil = {
   }
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/omap.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/omap.ts
 function resolveYamlOmap(data) {
   const objectKeys = /* @__PURE__ */ new Set();
   for (const object of data) {
@@ -54724,7 +54768,7 @@ var omap = {
   }
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/pairs.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/pairs.ts
 function resolveYamlPairs(data) {
   if (data === null) return true;
   return data.every((it) => isPlainObject(it) && Object.keys(it).length === 1);
@@ -54738,7 +54782,7 @@ var pairs = {
   resolve: resolveYamlPairs
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/regexp.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/regexp.ts
 var REGEXP = /^\/(?<regexp>[\s\S]+)\/(?<modifiers>[gismuy]*)$/;
 var regexp = {
   tag: "tag:yaml.org,2002:js/regexp",
@@ -54761,7 +54805,7 @@ var regexp = {
   represent: (object) => object.toString()
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/seq.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/seq.ts
 var seq = {
   tag: "tag:yaml.org,2002:seq",
   kind: "sequence",
@@ -54769,7 +54813,7 @@ var seq = {
   construct: (data) => data !== null ? data : []
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/set.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/set.ts
 var set = {
   tag: "tag:yaml.org,2002:set",
   kind: "mapping",
@@ -54780,7 +54824,7 @@ var set = {
   }
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/str.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/str.ts
 var str = {
   tag: "tag:yaml.org,2002:str",
   kind: "scalar",
@@ -54788,7 +54832,7 @@ var str = {
   construct: (data) => data !== null ? data : ""
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/timestamp.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/timestamp.ts
 var YAML_DATE_REGEXP = new RegExp(
   "^([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])$"
   // [3] day
@@ -54853,7 +54897,7 @@ var timestamp = {
   resolve: resolveYamlTimestamp
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.11/_type/undefined.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.12/_type/undefined.ts
 var undefinedType = {
   tag: "tag:yaml.org,2002:js/undefined",
   kind: "scalar",
@@ -54871,7 +54915,7 @@ var undefinedType = {
   }
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.11/_schema.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.12/_schema.ts
 function createTypeMap(implicitTypes, explicitTypes) {
   const result = {
     fallback: /* @__PURE__ */ new Map(),
@@ -54922,7 +54966,7 @@ var SCHEMA_MAP = /* @__PURE__ */ new Map([
   ["extended", EXTENDED_SCHEMA]
 ]);
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.11/_loader_state.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.12/_loader_state.ts
 var CONTEXT_FLOW_IN = 1;
 var CONTEXT_FLOW_OUT = 2;
 var CONTEXT_BLOCK_IN = 3;
@@ -55051,12 +55095,29 @@ function writeFoldedLines(count) {
   if (count > 1) return "\n".repeat(count - 1);
   return "";
 }
+var Scanner = class {
+  source;
+  #length;
+  position = 0;
+  constructor(source) {
+    source += "\0";
+    this.source = source;
+    this.#length = source.length;
+  }
+  peek(offset = 0) {
+    return this.source.charCodeAt(this.position + offset);
+  }
+  next() {
+    this.position += 1;
+  }
+  eof() {
+    return this.position >= this.#length - 1;
+  }
+};
 var LoaderState = class {
-  input;
-  length;
+  #scanner;
   lineIndent = 0;
   lineStart = 0;
-  position = 0;
   line = 0;
   onWarning;
   allowDuplicateKeys;
@@ -55070,48 +55131,44 @@ var LoaderState = class {
     onWarning,
     allowDuplicateKeys = false
   }) {
-    this.input = input;
+    this.#scanner = new Scanner(input);
     this.onWarning = onWarning;
     this.allowDuplicateKeys = allowDuplicateKeys;
     this.implicitTypes = schema.implicitTypes;
     this.typeMap = schema.typeMap;
-    this.length = input.length;
     this.readIndent();
   }
   skipWhitespaces() {
-    let ch = this.peek();
+    let ch = this.#scanner.peek();
     while (isWhiteSpace(ch)) {
-      ch = this.next();
+      this.#scanner.next();
+      ch = this.#scanner.peek();
     }
   }
   skipComment() {
-    let ch = this.peek();
+    let ch = this.#scanner.peek();
     if (ch !== SHARP) return;
-    ch = this.next();
+    this.#scanner.next();
+    ch = this.#scanner.peek();
     while (ch !== 0 && !isEOL(ch)) {
-      ch = this.next();
+      this.#scanner.next();
+      ch = this.#scanner.peek();
     }
   }
   readIndent() {
-    let char = this.peek();
-    while (char === SPACE) {
+    let ch = this.#scanner.peek();
+    while (ch === SPACE) {
       this.lineIndent += 1;
-      char = this.next();
+      this.#scanner.next();
+      ch = this.#scanner.peek();
     }
-  }
-  peek(offset = 0) {
-    return this.input.charCodeAt(this.position + offset);
-  }
-  next() {
-    this.position += 1;
-    return this.peek();
   }
   #createError(message2) {
     const mark = markToString(
-      this.input,
-      this.position,
+      this.#scanner.source,
+      this.#scanner.position,
       this.line,
-      this.position - this.lineStart
+      this.#scanner.position - this.lineStart
     );
     return new SyntaxError(`${message2} ${mark}`);
   }
@@ -55173,7 +55230,7 @@ var LoaderState = class {
   }
   captureSegment(start, end, checkJson) {
     if (start < end) {
-      const result = this.input.slice(start, end);
+      const result = this.#scanner.source.slice(start, end);
       if (checkJson) {
         for (let position = 0; position < result.length; position++) {
           const character = result.charCodeAt(position);
@@ -55193,21 +55250,21 @@ var LoaderState = class {
     let detected = false;
     const result = [];
     if (anchor !== null) this.anchorMap.set(anchor, result);
-    let ch = this.peek();
+    let ch = this.#scanner.peek();
     while (ch !== 0) {
       if (ch !== MINUS) {
         break;
       }
-      const following = this.peek(1);
+      const following = this.#scanner.peek(1);
       if (!isWhiteSpaceOrEOL(following)) {
         break;
       }
       detected = true;
-      this.position++;
+      this.#scanner.next();
       if (this.skipSeparationSpace(true, -1)) {
         if (this.lineIndent <= nodeIndent) {
           result.push(null);
-          ch = this.peek();
+          ch = this.#scanner.peek();
           continue;
         }
       }
@@ -55220,7 +55277,7 @@ var LoaderState = class {
       });
       if (newState) result.push(newState.result);
       this.skipSeparationSpace(true, -1);
-      ch = this.peek();
+      ch = this.#scanner.peek();
       if ((this.line === line || this.lineIndent > nodeIndent) && ch !== 0) {
         throw this.#createError(
           "Cannot read block sequence: bad indentation of a sequence entry"
@@ -55281,7 +55338,7 @@ var LoaderState = class {
     } else {
       if (!this.allowDuplicateKeys && !overridableKeys.has(keyNode) && Object.hasOwn(result, keyNode)) {
         this.line = startLine || this.line;
-        this.position = startPos || this.position;
+        this.#scanner.position = startPos || this.#scanner.position;
         throw this.#createError("Cannot store mapping pair: duplicated key");
       }
       Object.defineProperty(result, keyNode, {
@@ -55295,37 +55352,37 @@ var LoaderState = class {
     return result;
   }
   readLineBreak() {
-    const ch = this.peek();
+    const ch = this.#scanner.peek();
     if (ch === LINE_FEED) {
-      this.position++;
+      this.#scanner.next();
     } else if (ch === CARRIAGE_RETURN) {
-      this.position++;
-      if (this.peek() === LINE_FEED) {
-        this.position++;
+      this.#scanner.next();
+      if (this.#scanner.peek() === LINE_FEED) {
+        this.#scanner.next();
       }
     } else {
       throw this.#createError("Cannot read line: line break not found");
     }
     this.line += 1;
-    this.lineStart = this.position;
+    this.lineStart = this.#scanner.position;
   }
   skipSeparationSpace(allowComments, checkIndent) {
     let lineBreaks = 0;
-    let ch = this.peek();
+    let ch = this.#scanner.peek();
     while (ch !== 0) {
       this.skipWhitespaces();
-      ch = this.peek();
+      ch = this.#scanner.peek();
       if (allowComments) {
         this.skipComment();
-        ch = this.peek();
+        ch = this.#scanner.peek();
       }
       if (isEOL(ch)) {
         this.readLineBreak();
-        ch = this.peek();
+        ch = this.#scanner.peek();
         lineBreaks++;
         this.lineIndent = 0;
         this.readIndent();
-        ch = this.peek();
+        ch = this.#scanner.peek();
       } else {
         break;
       }
@@ -55336,9 +55393,9 @@ var LoaderState = class {
     return lineBreaks;
   }
   testDocumentSeparator() {
-    let ch = this.peek();
-    if ((ch === MINUS || ch === DOT) && ch === this.peek(1) && ch === this.peek(2)) {
-      ch = this.peek(3);
+    let ch = this.#scanner.peek();
+    if ((ch === MINUS || ch === DOT) && ch === this.#scanner.peek(1) && ch === this.#scanner.peek(2)) {
+      ch = this.#scanner.peek(3);
       if (ch === 0 || isWhiteSpaceOrEOL(ch)) {
         return true;
       }
@@ -55346,34 +55403,34 @@ var LoaderState = class {
     return false;
   }
   readPlainScalar(tag, anchor, nodeIndent, withinFlowCollection) {
-    let ch = this.peek();
+    let ch = this.#scanner.peek();
     if (isWhiteSpaceOrEOL(ch) || isFlowIndicator(ch) || ch === SHARP || ch === AMPERSAND || ch === ASTERISK || ch === EXCLAMATION || ch === VERTICAL_LINE || ch === GREATER_THAN || ch === SINGLE_QUOTE || ch === DOUBLE_QUOTE || ch === PERCENT || ch === COMMERCIAL_AT || ch === GRAVE_ACCENT) {
       return;
     }
     let following;
     if (ch === QUESTION || ch === MINUS) {
-      following = this.peek(1);
+      following = this.#scanner.peek(1);
       if (isWhiteSpaceOrEOL(following) || withinFlowCollection && isFlowIndicator(following)) {
         return;
       }
     }
     let result = "";
-    let captureEnd = this.position;
-    let captureStart = this.position;
+    let captureEnd = this.#scanner.position;
+    let captureStart = this.#scanner.position;
     let hasPendingContent = false;
     let line = 0;
     while (ch !== 0) {
       if (ch === COLON) {
-        following = this.peek(1);
+        following = this.#scanner.peek(1);
         if (isWhiteSpaceOrEOL(following) || withinFlowCollection && isFlowIndicator(following)) {
           break;
         }
       } else if (ch === SHARP) {
-        const preceding = this.peek(-1);
+        const preceding = this.#scanner.peek(-1);
         if (isWhiteSpaceOrEOL(preceding)) {
           break;
         }
-      } else if (this.position === this.lineStart && this.testDocumentSeparator() || withinFlowCollection && isFlowIndicator(ch)) {
+      } else if (this.#scanner.position === this.lineStart && this.testDocumentSeparator() || withinFlowCollection && isFlowIndicator(ch)) {
         break;
       } else if (isEOL(ch)) {
         line = this.line;
@@ -55382,10 +55439,10 @@ var LoaderState = class {
         this.skipSeparationSpace(false, -1);
         if (this.lineIndent >= nodeIndent) {
           hasPendingContent = true;
-          ch = this.peek();
+          ch = this.#scanner.peek();
           continue;
         } else {
-          this.position = captureEnd;
+          this.#scanner.position = captureEnd;
           this.line = line;
           this.lineStart = lineStart;
           this.lineIndent = lineIndent;
@@ -55396,13 +55453,14 @@ var LoaderState = class {
         const segment2 = this.captureSegment(captureStart, captureEnd, false);
         if (segment2) result += segment2;
         result += writeFoldedLines(this.line - line);
-        captureStart = captureEnd = this.position;
+        captureStart = captureEnd = this.#scanner.position;
         hasPendingContent = false;
       }
       if (!isWhiteSpace(ch)) {
-        captureEnd = this.position + 1;
+        captureEnd = this.#scanner.position + 1;
       }
-      ch = this.next();
+      this.#scanner.next();
+      ch = this.#scanner.peek();
     }
     const segment = this.captureSegment(captureStart, captureEnd, false);
     if (segment) result += segment;
@@ -55410,22 +55468,27 @@ var LoaderState = class {
     if (result) return { tag, anchor, kind: "scalar", result };
   }
   readSingleQuotedScalar(tag, anchor, nodeIndent) {
-    let ch = this.peek();
+    let ch = this.#scanner.peek();
     if (ch !== SINGLE_QUOTE) return;
     let result = "";
-    this.position++;
-    let captureStart = this.position;
-    let captureEnd = this.position;
-    ch = this.peek();
+    this.#scanner.next();
+    let captureStart = this.#scanner.position;
+    let captureEnd = this.#scanner.position;
+    ch = this.#scanner.peek();
     while (ch !== 0) {
       if (ch === SINGLE_QUOTE) {
-        const segment = this.captureSegment(captureStart, this.position, true);
+        const segment = this.captureSegment(
+          captureStart,
+          this.#scanner.position,
+          true
+        );
         if (segment) result += segment;
-        ch = this.next();
+        this.#scanner.next();
+        ch = this.#scanner.peek();
         if (ch === SINGLE_QUOTE) {
-          captureStart = this.position;
-          this.position++;
-          captureEnd = this.position;
+          captureStart = this.#scanner.position;
+          this.#scanner.next();
+          captureEnd = this.#scanner.position;
         } else {
           if (anchor !== null) this.anchorMap.set(anchor, result);
           return { tag, anchor, kind: "scalar", result };
@@ -55436,52 +55499,62 @@ var LoaderState = class {
         result += writeFoldedLines(
           this.skipSeparationSpace(false, nodeIndent)
         );
-        captureStart = captureEnd = this.position;
-      } else if (this.position === this.lineStart && this.testDocumentSeparator()) {
+        captureStart = captureEnd = this.#scanner.position;
+      } else if (this.#scanner.position === this.lineStart && this.testDocumentSeparator()) {
         throw this.#createError(
           "Unexpected end of the document within a single quoted scalar"
         );
       } else {
-        this.position++;
-        captureEnd = this.position;
+        this.#scanner.next();
+        captureEnd = this.#scanner.position;
       }
-      ch = this.peek();
+      ch = this.#scanner.peek();
     }
     throw this.#createError(
       "Unexpected end of the stream within a single quoted scalar"
     );
   }
   readDoubleQuotedScalar(tag, anchor, nodeIndent) {
-    let ch = this.peek();
+    let ch = this.#scanner.peek();
     if (ch !== DOUBLE_QUOTE) return;
     let result = "";
-    this.position++;
-    let captureEnd = this.position;
-    let captureStart = this.position;
+    this.#scanner.next();
+    let captureEnd = this.#scanner.position;
+    let captureStart = this.#scanner.position;
     let tmp;
-    ch = this.peek();
+    ch = this.#scanner.peek();
     while (ch !== 0) {
       if (ch === DOUBLE_QUOTE) {
-        const segment = this.captureSegment(captureStart, this.position, true);
+        const segment = this.captureSegment(
+          captureStart,
+          this.#scanner.position,
+          true
+        );
         if (segment) result += segment;
-        this.position++;
+        this.#scanner.next();
         if (anchor !== null) this.anchorMap.set(anchor, result);
         return { tag, anchor, kind: "scalar", result };
       }
       if (ch === BACKSLASH) {
-        const segment = this.captureSegment(captureStart, this.position, true);
+        const segment = this.captureSegment(
+          captureStart,
+          this.#scanner.position,
+          true
+        );
         if (segment) result += segment;
-        ch = this.next();
+        this.#scanner.next();
+        ch = this.#scanner.peek();
         if (isEOL(ch)) {
           this.skipSeparationSpace(false, nodeIndent);
         } else if (ch < 256 && SIMPLE_ESCAPE_SEQUENCES.has(ch)) {
           result += SIMPLE_ESCAPE_SEQUENCES.get(ch);
-          this.position++;
+          this.#scanner.next();
         } else if ((tmp = ESCAPED_HEX_LENGTHS.get(ch) ?? 0) > 0) {
           let hexLength = tmp;
           let hexResult = 0;
           for (; hexLength > 0; hexLength--) {
-            ch = this.next();
+            this.#scanner.next();
+            ch = this.#scanner.peek();
             if ((tmp = hexCharCodeToNumber(ch)) >= 0) {
               hexResult = (hexResult << 4) + tmp;
             } else {
@@ -55491,36 +55564,36 @@ var LoaderState = class {
             }
           }
           result += codepointToChar(hexResult);
-          this.position++;
+          this.#scanner.next();
         } else {
           throw this.#createError(
             "Cannot read double quoted scalar: unknown escape sequence"
           );
         }
-        captureStart = captureEnd = this.position;
+        captureStart = captureEnd = this.#scanner.position;
       } else if (isEOL(ch)) {
         const segment = this.captureSegment(captureStart, captureEnd, true);
         if (segment) result += segment;
         result += writeFoldedLines(
           this.skipSeparationSpace(false, nodeIndent)
         );
-        captureStart = captureEnd = this.position;
-      } else if (this.position === this.lineStart && this.testDocumentSeparator()) {
+        captureStart = captureEnd = this.#scanner.position;
+      } else if (this.#scanner.position === this.lineStart && this.testDocumentSeparator()) {
         throw this.#createError(
           "Unexpected end of the document within a double quoted scalar"
         );
       } else {
-        this.position++;
-        captureEnd = this.position;
+        this.#scanner.next();
+        captureEnd = this.#scanner.position;
       }
-      ch = this.peek();
+      ch = this.#scanner.peek();
     }
     throw this.#createError(
       "Unexpected end of the stream within a double quoted scalar"
     );
   }
   readFlowCollection(tag, anchor, nodeIndent) {
-    let ch = this.peek();
+    let ch = this.#scanner.peek();
     let terminator;
     let isMapping = true;
     let result = {};
@@ -55534,7 +55607,8 @@ var LoaderState = class {
       return;
     }
     if (anchor !== null) this.anchorMap.set(anchor, result);
-    ch = this.next();
+    this.#scanner.next();
+    ch = this.#scanner.peek();
     let readNext = true;
     let valueNode = null;
     let keyNode = null;
@@ -55546,9 +55620,9 @@ var LoaderState = class {
     const overridableKeys = /* @__PURE__ */ new Set();
     while (ch !== 0) {
       this.skipSeparationSpace(true, nodeIndent);
-      ch = this.peek();
+      ch = this.#scanner.peek();
       if (ch === terminator) {
-        this.position++;
+        this.#scanner.next();
         const kind = isMapping ? "mapping" : "sequence";
         return { tag, anchor, kind, result };
       }
@@ -55560,10 +55634,10 @@ var LoaderState = class {
       keyTag = keyNode = valueNode = null;
       isPair = isExplicitPair = false;
       if (ch === QUESTION) {
-        following = this.peek(1);
+        following = this.#scanner.peek(1);
         if (isWhiteSpaceOrEOL(following)) {
           isPair = isExplicitPair = true;
-          this.position++;
+          this.#scanner.next();
           this.skipSeparationSpace(true, nodeIndent);
         }
       }
@@ -55579,10 +55653,11 @@ var LoaderState = class {
         keyNode = newState.result;
       }
       this.skipSeparationSpace(true, nodeIndent);
-      ch = this.peek();
+      ch = this.#scanner.peek();
       if ((isExplicitPair || this.line === line) && ch === COLON) {
         isPair = true;
-        ch = this.next();
+        this.#scanner.next();
+        ch = this.#scanner.peek();
         this.skipSeparationSpace(true, nodeIndent);
         const newState2 = this.composeNode({
           parentIndent: nodeIndent,
@@ -55614,10 +55689,11 @@ var LoaderState = class {
         result.push(keyNode);
       }
       this.skipSeparationSpace(true, nodeIndent);
-      ch = this.peek();
+      ch = this.#scanner.peek();
       if (ch === COMMA) {
         readNext = true;
-        ch = this.next();
+        this.#scanner.next();
+        ch = this.#scanner.peek();
       } else {
         readNext = false;
       }
@@ -55635,7 +55711,7 @@ var LoaderState = class {
     let textIndent = nodeIndent;
     let emptyLines = 0;
     let atMoreIndented = false;
-    let ch = this.peek();
+    let ch = this.#scanner.peek();
     let folding = false;
     if (ch === VERTICAL_LINE) {
       folding = false;
@@ -55647,7 +55723,8 @@ var LoaderState = class {
     let result = "";
     let tmp = 0;
     while (ch !== 0) {
-      ch = this.next();
+      this.#scanner.next();
+      ch = this.#scanner.peek();
       if (ch === PLUS || ch === MINUS) {
         if (CHOMPING_CLIP === chomping) {
           chomping = ch === PLUS ? CHOMPING_KEEP : CHOMPING_STRIP;
@@ -55676,15 +55753,16 @@ var LoaderState = class {
     if (isWhiteSpace(ch)) {
       this.skipWhitespaces();
       this.skipComment();
-      ch = this.peek();
+      ch = this.#scanner.peek();
     }
     while (ch !== 0) {
       this.readLineBreak();
       this.lineIndent = 0;
-      ch = this.peek();
+      ch = this.#scanner.peek();
       while ((!detectedIndent || this.lineIndent < textIndent) && ch === SPACE) {
         this.lineIndent++;
-        ch = this.next();
+        this.#scanner.next();
+        ch = this.#scanner.peek();
       }
       if (!detectedIndent && this.lineIndent > textIndent) {
         textIndent = this.lineIndent;
@@ -55729,11 +55807,16 @@ var LoaderState = class {
       didReadContent = true;
       detectedIndent = true;
       emptyLines = 0;
-      const captureStart = this.position;
+      const captureStart = this.#scanner.position;
       while (!isEOL(ch) && ch !== 0) {
-        ch = this.next();
+        this.#scanner.next();
+        ch = this.#scanner.peek();
       }
-      const segment = this.captureSegment(captureStart, this.position, false);
+      const segment = this.captureSegment(
+        captureStart,
+        this.#scanner.position,
+        false
+      );
       if (segment) result += segment;
     }
     if (anchor !== null) this.anchorMap.set(anchor, result);
@@ -55751,11 +55834,11 @@ var LoaderState = class {
     let atExplicitKey = false;
     let detected = false;
     if (anchor !== null) this.anchorMap.set(anchor, result);
-    let ch = this.peek();
+    let ch = this.#scanner.peek();
     while (ch !== 0) {
-      const following = this.peek(1);
+      const following = this.#scanner.peek(1);
       line = this.line;
-      pos = this.position;
+      pos = this.#scanner.position;
       if ((ch === QUESTION || ch === COLON) && isWhiteSpaceOrEOL(following)) {
         if (ch === QUESTION) {
           if (atExplicitKey) {
@@ -55781,7 +55864,7 @@ var LoaderState = class {
             "Cannot read block as explicit mapping pair is incomplete: a key node is missed or followed by a non-tabulated empty line"
           );
         }
-        this.position += 1;
+        this.#scanner.next();
         ch = following;
       } else {
         const newState = this.composeNode({
@@ -55792,11 +55875,12 @@ var LoaderState = class {
         });
         if (!newState) break;
         if (this.line === line) {
-          ch = this.peek();
+          ch = this.#scanner.peek();
           this.skipWhitespaces();
-          ch = this.peek();
+          ch = this.#scanner.peek();
           if (ch === COLON) {
-            ch = this.next();
+            this.#scanner.next();
+            ch = this.#scanner.peek();
             if (!isWhiteSpaceOrEOL(ch)) {
               throw this.#createError(
                 "Cannot read block: a whitespace character is expected after the key-value separator within a block mapping"
@@ -55863,7 +55947,7 @@ var LoaderState = class {
           keyTag = keyNode = valueNode = null;
         }
         this.skipSeparationSpace(true, -1);
-        ch = this.peek();
+        ch = this.#scanner.peek();
       }
       if (this.lineIndent > nodeIndent && ch !== 0) {
         throw this.#createError(
@@ -55889,32 +55973,37 @@ var LoaderState = class {
     let isNamed = false;
     let tagHandle = "";
     let tagName;
-    let ch = this.peek();
+    let ch = this.#scanner.peek();
     if (ch !== EXCLAMATION) return;
     if (tag !== null) {
       throw this.#createError(
         "Cannot read tag property: duplication of a tag property"
       );
     }
-    ch = this.next();
+    this.#scanner.next();
+    ch = this.#scanner.peek();
     if (ch === SMALLER_THAN) {
       isVerbatim = true;
-      ch = this.next();
+      this.#scanner.next();
+      ch = this.#scanner.peek();
     } else if (ch === EXCLAMATION) {
       isNamed = true;
       tagHandle = "!!";
-      ch = this.next();
+      this.#scanner.next();
+      ch = this.#scanner.peek();
     } else {
       tagHandle = "!";
     }
-    let position = this.position;
+    let position = this.#scanner.position;
     if (isVerbatim) {
       do {
-        ch = this.next();
+        this.#scanner.next();
+        ch = this.#scanner.peek();
       } while (ch !== 0 && ch !== GREATER_THAN);
-      if (this.position < this.length) {
-        tagName = this.input.slice(position, this.position);
-        ch = this.next();
+      if (!this.#scanner.eof()) {
+        tagName = this.#scanner.source.slice(position, this.#scanner.position);
+        this.#scanner.next();
+        ch = this.#scanner.peek();
       } else {
         throw this.#createError(
           "Cannot read tag property: unexpected end of stream"
@@ -55924,23 +56013,27 @@ var LoaderState = class {
       while (ch !== 0 && !isWhiteSpaceOrEOL(ch)) {
         if (ch === EXCLAMATION) {
           if (!isNamed) {
-            tagHandle = this.input.slice(position - 1, this.position + 1);
+            tagHandle = this.#scanner.source.slice(
+              position - 1,
+              this.#scanner.position + 1
+            );
             if (!PATTERN_TAG_HANDLE.test(tagHandle)) {
               throw this.#createError(
                 "Cannot read tag property: named tag handle contains invalid characters"
               );
             }
             isNamed = true;
-            position = this.position + 1;
+            position = this.#scanner.position + 1;
           } else {
             throw this.#createError(
               "Cannot read tag property: tag suffix cannot contain an exclamation mark"
             );
           }
         }
-        ch = this.next();
+        this.#scanner.next();
+        ch = this.#scanner.peek();
       }
-      tagName = this.input.slice(position, this.position);
+      tagName = this.#scanner.source.slice(position, this.#scanner.position);
       if (PATTERN_FLOW_INDICATORS.test(tagName)) {
         throw this.#createError(
           "Cannot read tag property: tag suffix cannot contain flow indicator characters"
@@ -55966,38 +56059,42 @@ var LoaderState = class {
     );
   }
   readAnchorProperty(anchor) {
-    let ch = this.peek();
+    let ch = this.#scanner.peek();
     if (ch !== AMPERSAND) return;
     if (anchor !== null) {
       throw this.#createError(
         "Cannot read anchor property: duplicate anchor property"
       );
     }
-    ch = this.next();
-    const position = this.position;
+    this.#scanner.next();
+    ch = this.#scanner.peek();
+    const position = this.#scanner.position;
     while (ch !== 0 && !isWhiteSpaceOrEOL(ch) && !isFlowIndicator(ch)) {
-      ch = this.next();
+      this.#scanner.next();
+      ch = this.#scanner.peek();
     }
-    if (this.position === position) {
+    if (this.#scanner.position === position) {
       throw this.#createError(
         "Cannot read anchor property: name of an anchor node must contain at least one character"
       );
     }
-    return this.input.slice(position, this.position);
+    return this.#scanner.source.slice(position, this.#scanner.position);
   }
   readAlias() {
-    if (this.peek() !== ASTERISK) return;
-    let ch = this.next();
-    const position = this.position;
+    if (this.#scanner.peek() !== ASTERISK) return;
+    this.#scanner.next();
+    let ch = this.#scanner.peek();
+    const position = this.#scanner.position;
     while (ch !== 0 && !isWhiteSpaceOrEOL(ch) && !isFlowIndicator(ch)) {
-      ch = this.next();
+      this.#scanner.next();
+      ch = this.#scanner.peek();
     }
-    if (this.position === position) {
+    if (this.#scanner.position === position) {
       throw this.#createError(
         "Cannot read alias: alias name must contain at least one character"
       );
     }
-    const alias = this.input.slice(position, this.position);
+    const alias = this.#scanner.source.slice(position, this.#scanner.position);
     if (!this.anchorMap.has(alias)) {
       throw this.#createError(
         `Cannot read alias: unidentified alias "${alias}"`
@@ -56088,7 +56185,7 @@ var LoaderState = class {
       const cond = CONTEXT_FLOW_IN === nodeContext || CONTEXT_FLOW_OUT === nodeContext;
       const flowIndent = cond ? parentIndent : parentIndent + 1;
       if (allowBlockCollections) {
-        const blockIndent = this.position - this.lineStart;
+        const blockIndent = this.#scanner.position - this.lineStart;
         const blockSequenceState = this.readBlockSequence(
           tag,
           anchor,
@@ -56149,7 +56246,7 @@ var LoaderState = class {
         return this.resolveTag(plainScalarState);
       }
     } else if (indentStatus === 0 && CONTEXT_BLOCK_OUT === nodeContext && allowBlockCollections) {
-      const blockIndent = this.position - this.lineStart;
+      const blockIndent = this.#scanner.position - this.lineStart;
       const newState2 = this.readBlockSequence(tag, anchor, blockIndent);
       if (newState2) return this.resolveTag(newState2);
     }
@@ -56159,20 +56256,25 @@ var LoaderState = class {
   readDirectives() {
     let hasDirectives = false;
     let version = null;
-    let ch = this.peek();
+    let ch = this.#scanner.peek();
     while (ch !== 0) {
       this.skipSeparationSpace(true, -1);
-      ch = this.peek();
+      ch = this.#scanner.peek();
       if (this.lineIndent > 0 || ch !== PERCENT) {
         break;
       }
       hasDirectives = true;
-      ch = this.next();
-      let position = this.position;
+      this.#scanner.next();
+      ch = this.#scanner.peek();
+      let position = this.#scanner.position;
       while (ch !== 0 && !isWhiteSpaceOrEOL(ch)) {
-        ch = this.next();
+        this.#scanner.next();
+        ch = this.#scanner.peek();
       }
-      const directiveName = this.input.slice(position, this.position);
+      const directiveName = this.#scanner.source.slice(
+        position,
+        this.#scanner.position
+      );
       const directiveArgs = [];
       if (directiveName.length < 1) {
         throw this.#createError(
@@ -56182,13 +56284,16 @@ var LoaderState = class {
       while (ch !== 0) {
         this.skipWhitespaces();
         this.skipComment();
-        ch = this.peek();
+        ch = this.#scanner.peek();
         if (isEOL(ch)) break;
-        position = this.position;
+        position = this.#scanner.position;
         while (ch !== 0 && !isWhiteSpaceOrEOL(ch)) {
-          ch = this.next();
+          this.#scanner.next();
+          ch = this.#scanner.peek();
         }
-        directiveArgs.push(this.input.slice(position, this.position));
+        directiveArgs.push(
+          this.#scanner.source.slice(position, this.#scanner.position)
+        );
       }
       if (ch !== 0) this.readLineBreak();
       switch (directiveName) {
@@ -56207,20 +56312,20 @@ var LoaderState = class {
           this.dispatchWarning(`unknown document directive "${directiveName}"`);
           break;
       }
-      ch = this.peek();
+      ch = this.#scanner.peek();
     }
     return hasDirectives;
   }
   readDocument() {
-    const documentStart = this.position;
+    const documentStart = this.#scanner.position;
     this.checkLineBreaks = false;
     this.tagMap = /* @__PURE__ */ new Map();
     this.anchorMap = /* @__PURE__ */ new Map();
     const hasDirectives = this.readDirectives();
     this.skipSeparationSpace(true, -1);
     let result = null;
-    if (this.lineIndent === 0 && this.peek() === MINUS && this.peek(1) === MINUS && this.peek(2) === MINUS) {
-      this.position += 3;
+    if (this.lineIndent === 0 && this.#scanner.peek() === MINUS && this.#scanner.peek(1) === MINUS && this.#scanner.peek(2) === MINUS) {
+      this.#scanner.position += 3;
       this.skipSeparationSpace(true, -1);
     } else if (hasDirectives) {
       throw this.#createError(
@@ -56236,16 +56341,16 @@ var LoaderState = class {
     if (newState) result = newState.result;
     this.skipSeparationSpace(true, -1);
     if (this.checkLineBreaks && PATTERN_NON_ASCII_LINE_BREAKS.test(
-      this.input.slice(documentStart, this.position)
+      this.#scanner.source.slice(documentStart, this.#scanner.position)
     )) {
       this.dispatchWarning("non-ASCII line breaks are interpreted as content");
     }
-    if (this.position === this.lineStart && this.testDocumentSeparator()) {
-      if (this.peek() === DOT) {
-        this.position += 3;
+    if (this.#scanner.position === this.lineStart && this.testDocumentSeparator()) {
+      if (this.#scanner.peek() === DOT) {
+        this.#scanner.position += 3;
         this.skipSeparationSpace(true, -1);
       }
-    } else if (this.position < this.length - 1) {
+    } else if (!this.#scanner.eof()) {
       throw this.#createError(
         "Cannot read document: end of the stream or a document separator is expected"
       );
@@ -56253,20 +56358,19 @@ var LoaderState = class {
     return result;
   }
   *readDocuments() {
-    while (this.position < this.length - 1) {
+    while (!this.#scanner.eof()) {
       yield this.readDocument();
     }
   }
 };
 
-// npm/src/deps/jsr.io/@std/yaml/1.0.11/parse.ts
+// npm/src/deps/jsr.io/@std/yaml/1.0.12/parse.ts
 function sanitizeInput(input) {
   input = String(input);
   if (input.length > 0) {
     if (!isEOL(input.charCodeAt(input.length - 1))) input += "\n";
     if (input.charCodeAt(0) === 65279) input = input.slice(1);
   }
-  input += "\0";
   return input;
 }
 function parse(content, options = {}) {
@@ -56866,12 +56970,12 @@ var JSONParse = (text, reviver) => {
   const serializedData = text.replace(
     stringsOrLargeNumbers,
     (text2, digits, fractional, exponential) => {
-      const isString = text2[0] === '"';
-      const isNoise = isString && noiseValueWithQuotes.test(text2);
+      const isString2 = text2[0] === '"';
+      const isNoise = isString2 && noiseValueWithQuotes.test(text2);
       if (isNoise) return text2.substring(0, text2.length - 1) + 'n"';
       const isFractionalOrExponential = fractional || exponential;
       const isLessThanMaxSafeInt = digits && (digits.length < MAX_DIGITS || digits.length === MAX_DIGITS && digits <= MAX_INT);
-      if (isString || isFractionalOrExponential || isLessThanMaxSafeInt)
+      if (isString2 || isFractionalOrExponential || isLessThanMaxSafeInt)
         return text2;
       return '"' + text2 + 'n"';
     }
@@ -61888,7 +61992,6 @@ function expandJobSteps(steps, compositeInfos, compositeStepCounts, logBlocks) {
         name: `(sub) ${subStep.name}`,
         started_at: subStep.started_at,
         completed_at: subStep.completed_at,
-        number: apiStep.number,
         timelineRowKind: "composite-child"
       });
     });

--- a/dist/post.js
+++ b/dist/post.js
@@ -54049,12 +54049,18 @@ var filterSteps = (steps) => {
 var filterJobs = (jobs) => {
   return jobs.filter((job) => job.conclusion !== "skipped");
 };
-var createStepPosition = (workflow, jobStartedAt, step, previousTopLevelStepId) => {
+var createTopLevelStepPosition = (workflow, jobStartedAt, previousTopLevelStepId) => {
   if (previousTopLevelStepId === void 0) {
-    const startAt = step.timelineRowKind === "composite-child" ? step.started_at : jobStartedAt;
-    return formatElapsedTime(diffSec(workflow.run_started_at, startAt));
+    return formatElapsedTime(diffSec(workflow.run_started_at, jobStartedAt));
   }
-  return step.timelineRowKind === "composite-child" ? formatElapsedTime(diffSec(workflow.run_started_at, step.started_at)) : `after ${previousTopLevelStepId}`;
+  return `after ${previousTopLevelStepId}`;
+};
+var createCompositeChildPosition = (workflow, step, compositeChildAnchorId, previousCompositeChildId) => {
+  const anchorId = previousCompositeChildId ?? compositeChildAnchorId;
+  if (anchorId === void 0) {
+    return formatElapsedTime(diffSec(workflow.run_started_at, step.started_at));
+  }
+  return `after ${anchorId}`;
 };
 var createWaitingRunnerStep = (workflow, job, jobIndex) => {
   const status = "active";
@@ -54084,6 +54090,8 @@ var createGanttJobs = (workflow, workflowJobs, showWaitingRunner = true) => {
       if (completedSteps.length === 0) return void 0;
       const steps = [];
       let previousTopLevelStepId;
+      let compositeChildAnchorId;
+      let previousCompositeChildId;
       const waitingRunnerStep = createWaitingRunnerStep(
         workflow,
         job,
@@ -54093,24 +54101,34 @@ var createGanttJobs = (workflow, workflowJobs, showWaitingRunner = true) => {
         steps.push(waitingRunnerStep);
         previousTopLevelStepId = waitingRunnerStep.id;
       }
-      completedSteps.forEach((step) => {
+      completedSteps.forEach((step, stepIndex) => {
         const stepElapsedSec = diffSec(step.started_at, step.completed_at);
         const id = createGanttStepId(jobIndex, steps.length);
+        const nextStep = completedSteps[stepIndex + 1];
+        const position = step.timelineRowKind === "composite-child" ? createCompositeChildPosition(
+          workflow,
+          step,
+          compositeChildAnchorId,
+          previousCompositeChildId
+        ) : createTopLevelStepPosition(
+          workflow,
+          job.started_at,
+          previousTopLevelStepId
+        );
         steps.push({
           name: formatName(step.name, stepElapsedSec),
           id,
           status: convertStepToStatus(step.conclusion),
-          position: createStepPosition(
-            workflow,
-            job.started_at,
-            step,
-            previousTopLevelStepId
-          ),
+          position,
           sec: stepElapsedSec
         });
-        if (step.timelineRowKind !== "composite-child") {
-          previousTopLevelStepId = id;
+        if (step.timelineRowKind === "composite-child") {
+          previousCompositeChildId = id;
+          return;
         }
+        compositeChildAnchorId = nextStep?.timelineRowKind === "composite-child" ? previousTopLevelStepId : void 0;
+        previousCompositeChildId = void 0;
+        previousTopLevelStepId = id;
       });
       return { section, steps };
     }

--- a/src/composite.ts
+++ b/src/composite.ts
@@ -1,6 +1,7 @@
 import { decodeBase64 } from "@std/encoding";
 import { parse as parseYaml } from "@std/yaml";
 import { diffSec } from "./format_util.ts";
+import type { TimelineJobs, TimelineStep } from "./types.ts";
 import {
   type CompositeAction,
   Github,
@@ -15,7 +16,7 @@ export type ExpandCompositeOptions = {
   thresholdSec?: number; // default: 20
 };
 
-type CompositeStepInfo = {
+export type CompositeStepInfo = {
   apiStepIndex: number;
   apiStepName: string;
   usesPath: string;
@@ -287,6 +288,64 @@ export function extractSubSteps(
   });
 }
 
+export function expandJobSteps(
+  steps: NonNullable<WorkflowJobs[0]["steps"]>,
+  compositeInfos: CompositeStepInfo[],
+  compositeStepCounts: Map<string, number>,
+  logBlocks: LogBlock[],
+): TimelineStep[] {
+  const compositeInfoByIndex = new Map(
+    compositeInfos.map((info) => [info.apiStepIndex, info]),
+  );
+
+  const newSteps: TimelineStep[] = [];
+
+  for (let i = 0; i < steps.length; i++) {
+    const compositeInfo = compositeInfoByIndex.get(i);
+
+    if (!compositeInfo || !compositeStepCounts.has(compositeInfo.usesPath)) {
+      newSteps.push(steps[i]);
+      continue;
+    }
+
+    const apiStep = steps[i];
+    if (!apiStep.started_at || !apiStep.completed_at) {
+      newSteps.push(apiStep);
+      continue;
+    }
+
+    const expectedStepCount = compositeStepCounts.get(compositeInfo.usesPath)!;
+
+    const subSteps = extractSubSteps(
+      logBlocks,
+      apiStep.started_at,
+      apiStep.completed_at,
+      apiStep.status,
+      apiStep.conclusion,
+      compositeInfo.usesPath,
+      expectedStepCount,
+    );
+
+    newSteps.push(apiStep);
+    if (subSteps.length === 0) {
+      continue;
+    }
+
+    subSteps.forEach((subStep) => {
+      newSteps.push({
+        ...apiStep,
+        name: `(sub) ${subStep.name}`,
+        started_at: subStep.started_at,
+        completed_at: subStep.completed_at,
+        number: apiStep.number,
+        timelineRowKind: "composite-child",
+      });
+    });
+  }
+
+  return newSteps;
+}
+
 /**
  * Expand composite action steps in workflowJobs.
  * Returns a new WorkflowJobs with composite steps replaced by their sub-steps.
@@ -301,7 +360,7 @@ export async function expandCompositeSteps(
   workflowRun: WorkflowRun,
   workflowJobs: WorkflowJobs,
   options: ExpandCompositeOptions = {},
-): Promise<WorkflowJobs> {
+): Promise<TimelineJobs> {
   const thresholdSec = options.thresholdSec ?? 20;
 
   const workflowModel = await fetchWorkflowModel(client, workflowRun);
@@ -362,7 +421,7 @@ export async function expandCompositeSteps(
   );
   const logMap = new Map(logResults);
 
-  const expandedJobs: WorkflowJobs = workflowJobs.map((job) => {
+  const expandedJobs: TimelineJobs = workflowJobs.map((job) => {
     const compositeInfos = compositeMap.get(job.id);
     if (!compositeInfos || !job.steps) return job;
 
@@ -372,64 +431,15 @@ export async function expandCompositeSteps(
     const logBlocks = parseLogBlocks(logText);
     if (logBlocks.length === 0) return job;
 
-    // Precompute a lookup map from apiStepIndex to CompositeStepInfo
-    const compositeInfoByIndex = new Map(
-      compositeInfos.map((info) => [info.apiStepIndex, info]),
-    );
-
-    const newSteps: NonNullable<typeof job.steps> = [];
-
-    for (let i = 0; i < job.steps.length; i++) {
-      const compositeInfo = compositeInfoByIndex.get(i);
-
-      // Non-composite step or composite without known step count: keep as-is
-      if (
-        !compositeInfo || !compositeStepCounts.has(compositeInfo.usesPath)
-      ) {
-        newSteps.push(job.steps[i]);
-        continue;
-      }
-
-      // Composite step without timing data: keep as-is
-      const apiStep = job.steps[i];
-      if (!apiStep.started_at || !apiStep.completed_at) {
-        newSteps.push(apiStep);
-        continue;
-      }
-
-      const expectedStepCount = compositeStepCounts.get(
-        compositeInfo.usesPath,
-      )!;
-
-      const subSteps = extractSubSteps(
+    return {
+      ...job,
+      steps: expandJobSteps(
+        job.steps,
+        compositeInfos,
+        compositeStepCounts,
         logBlocks,
-        apiStep.started_at,
-        apiStep.completed_at,
-        apiStep.status,
-        apiStep.conclusion,
-        compositeInfo.usesPath,
-        expectedStepCount,
-      );
-
-      // Expansion failed: keep original step
-      if (subSteps.length === 0) {
-        newSteps.push(apiStep);
-        continue;
-      }
-
-      // Replace composite step with expanded sub-steps
-      for (const subStep of subSteps) {
-        newSteps.push({
-          ...apiStep,
-          name: `(sub) ${subStep.name}`,
-          started_at: subStep.started_at,
-          completed_at: subStep.completed_at,
-          number: apiStep.number,
-        });
-      }
-    }
-
-    return { ...job, steps: newSteps };
+      ),
+    };
   });
 
   return expandedJobs;

--- a/src/composite.ts
+++ b/src/composite.ts
@@ -337,7 +337,6 @@ export function expandJobSteps(
         name: `(sub) ${subStep.name}`,
         started_at: subStep.started_at,
         completed_at: subStep.completed_at,
-        number: apiStep.number,
         timelineRowKind: "composite-child",
       });
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,17 @@
+import type { WorkflowJobs } from "@kesin11/gha-utils";
+
+export type TimelineStep =
+  & NonNullable<WorkflowJobs[number]["steps"]>[number]
+  & {
+    timelineRowKind?: "composite-child";
+  };
+
+export type TimelineJob = Omit<WorkflowJobs[number], "steps"> & {
+  steps?: TimelineStep[];
+};
+
+export type TimelineJobs = TimelineJob[];
+
 export type ganttJob = {
   section: string;
   steps: ganttStep[];

--- a/src/workflow_gantt.ts
+++ b/src/workflow_gantt.ts
@@ -22,6 +22,8 @@ const MERMAID_MAX_CHAR = 50_000;
 
 type workflowJobSteps = NonNullable<TimelineJobs[0]["steps"]>;
 
+const isString = (value: unknown): value is string => typeof value === "string";
+
 const createGanttStepId = (
   jobIndex: number,
   stepIndex: number,
@@ -73,7 +75,7 @@ const createWaitingRunnerStep = (
   // job.created_at does not exist in < GHES v3.9.
   // So it is not possible to calculate the elapsed time the runner is waiting for a job, is not supported instead of the elapsed time.
   // Also, it is not possible to create an exact job start time position. So use job.started_at instead of job.created_at.
-  if (job.created_at === undefined) {
+  if (!isString(job.created_at) || !isString(job.started_at)) {
     return undefined;
   } else {
     // >= GHES v3.9 or GitHub.com
@@ -99,9 +101,17 @@ export const createGanttJobs = (
 ): ganttJob[] => {
   return filterJobs(workflowJobs).map(
     (job, jobIndex, _jobs): ganttJob | undefined => {
-      if (job.steps === undefined) return undefined;
+      if (
+        job.steps === undefined ||
+        !isString(job.name) ||
+        !isString(job.started_at)
+      ) {
+        return undefined;
+      }
 
-      const section = escapeName(job.name);
+      const jobName = job.name;
+      const jobStartedAt = job.started_at;
+      const section = escapeName(jobName);
       const completedSteps = filterSteps(job.steps);
       if (completedSteps.length === 0) return undefined;
 
@@ -133,7 +143,7 @@ export const createGanttJobs = (
           )
           : createTopLevelStepPosition(
             workflow,
-            job.started_at,
+            jobStartedAt,
             previousTopLevelStepId,
           );
 

--- a/src/workflow_gantt.ts
+++ b/src/workflow_gantt.ts
@@ -37,22 +37,30 @@ const filterJobs = (jobs: TimelineJobs): TimelineJobs => {
   return jobs.filter((job) => job.conclusion !== "skipped");
 };
 
-const createStepPosition = (
+const createTopLevelStepPosition = (
   workflow: WorkflowRun,
   jobStartedAt: string,
-  step: TimelineStep,
   previousTopLevelStepId?: ganttStep["id"],
 ): string => {
   if (previousTopLevelStepId === undefined) {
-    const startAt = step.timelineRowKind === "composite-child"
-      ? step.started_at
-      : jobStartedAt;
-    return formatElapsedTime(diffSec(workflow.run_started_at, startAt));
+    return formatElapsedTime(diffSec(workflow.run_started_at, jobStartedAt));
   }
 
-  return step.timelineRowKind === "composite-child"
-    ? formatElapsedTime(diffSec(workflow.run_started_at, step.started_at))
-    : `after ${previousTopLevelStepId}`;
+  return `after ${previousTopLevelStepId}`;
+};
+
+const createCompositeChildPosition = (
+  workflow: WorkflowRun,
+  step: TimelineStep,
+  compositeChildAnchorId?: ganttStep["id"],
+  previousCompositeChildId?: ganttStep["id"],
+): string => {
+  const anchorId = previousCompositeChildId ?? compositeChildAnchorId;
+  if (anchorId === undefined) {
+    return formatElapsedTime(diffSec(workflow.run_started_at, step.started_at));
+  }
+
+  return `after ${anchorId}`;
 };
 
 const createWaitingRunnerStep = (
@@ -99,6 +107,8 @@ export const createGanttJobs = (
 
       const steps: ganttStep[] = [];
       let previousTopLevelStepId: ganttStep["id"] | undefined;
+      let compositeChildAnchorId: ganttStep["id"] | undefined;
+      let previousCompositeChildId: ganttStep["id"] | undefined;
 
       const waitingRunnerStep = createWaitingRunnerStep(
         workflow,
@@ -110,25 +120,41 @@ export const createGanttJobs = (
         previousTopLevelStepId = waitingRunnerStep.id;
       }
 
-      completedSteps.forEach((step) => {
+      completedSteps.forEach((step, stepIndex) => {
         const stepElapsedSec = diffSec(step.started_at, step.completed_at);
         const id = createGanttStepId(jobIndex, steps.length);
+        const nextStep = completedSteps[stepIndex + 1];
+        const position = step.timelineRowKind === "composite-child"
+          ? createCompositeChildPosition(
+            workflow,
+            step,
+            compositeChildAnchorId,
+            previousCompositeChildId,
+          )
+          : createTopLevelStepPosition(
+            workflow,
+            job.started_at,
+            previousTopLevelStepId,
+          );
+
         steps.push({
           name: formatName(step.name, stepElapsedSec),
           id,
           status: convertStepToStatus(step.conclusion as StepConclusion),
-          position: createStepPosition(
-            workflow,
-            job.started_at,
-            step,
-            previousTopLevelStepId,
-          ),
+          position,
           sec: stepElapsedSec,
         });
 
-        if (step.timelineRowKind !== "composite-child") {
-          previousTopLevelStepId = id;
+        if (step.timelineRowKind === "composite-child") {
+          previousCompositeChildId = id;
+          return;
         }
+
+        compositeChildAnchorId = nextStep?.timelineRowKind === "composite-child"
+          ? previousTopLevelStepId
+          : undefined;
+        previousCompositeChildId = undefined;
+        previousTopLevelStepId = id;
       });
 
       return { section, steps };

--- a/src/workflow_gantt.ts
+++ b/src/workflow_gantt.ts
@@ -1,5 +1,5 @@
 import { sumOf } from "@std/collections";
-import type { WorkflowJobs, WorkflowRun } from "@kesin11/gha-utils";
+import type { WorkflowRun } from "@kesin11/gha-utils";
 import {
   convertStepToStatus,
   diffSec,
@@ -13,12 +13,19 @@ import type {
   GanttOptions,
   ganttStep,
   StepConclusion,
+  TimelineJobs,
+  TimelineStep,
 } from "./types.ts";
 
 // ref: MAX_TEXTLENGTH https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/mermaidAPI.ts
 const MERMAID_MAX_CHAR = 50_000;
 
-type workflowJobSteps = NonNullable<WorkflowJobs[0]["steps"]>;
+type workflowJobSteps = NonNullable<TimelineJobs[0]["steps"]>;
+
+const createGanttStepId = (
+  jobIndex: number,
+  stepIndex: number,
+): ganttStep["id"] => `job${jobIndex}-${stepIndex}`;
 
 // Skip steps that is not status:completed (ex. status:queued, status:in_progress)
 const filterSteps = (steps: workflowJobSteps): workflowJobSteps => {
@@ -26,13 +33,31 @@ const filterSteps = (steps: workflowJobSteps): workflowJobSteps => {
 };
 
 // Skip jobs that is conclusion:skipped
-const filterJobs = (jobs: WorkflowJobs): WorkflowJobs => {
+const filterJobs = (jobs: TimelineJobs): TimelineJobs => {
   return jobs.filter((job) => job.conclusion !== "skipped");
+};
+
+const createStepPosition = (
+  workflow: WorkflowRun,
+  jobStartedAt: string,
+  step: TimelineStep,
+  previousTopLevelStepId?: ganttStep["id"],
+): string => {
+  if (previousTopLevelStepId === undefined) {
+    const startAt = step.timelineRowKind === "composite-child"
+      ? step.started_at
+      : jobStartedAt;
+    return formatElapsedTime(diffSec(workflow.run_started_at, startAt));
+  }
+
+  return step.timelineRowKind === "composite-child"
+    ? formatElapsedTime(diffSec(workflow.run_started_at, step.started_at))
+    : `after ${previousTopLevelStepId}`;
 };
 
 const createWaitingRunnerStep = (
   workflow: WorkflowRun,
-  job: WorkflowJobs[0],
+  job: TimelineJobs[0],
   jobIndex: number,
 ): ganttStep | undefined => {
   const status: ganttStep["status"] = "active";
@@ -51,7 +76,7 @@ const createWaitingRunnerStep = (
     const waitingRunnerElapsedSec = diffSec(job.created_at, job.started_at);
     return {
       name: formatName("Waiting for a runner", waitingRunnerElapsedSec),
-      id: `job${jobIndex}-0`,
+      id: createGanttStepId(jobIndex, 0),
       status,
       position: formatElapsedTime(startJobElapsedSec),
       sec: waitingRunnerElapsedSec,
@@ -61,7 +86,7 @@ const createWaitingRunnerStep = (
 
 export const createGanttJobs = (
   workflow: WorkflowRun,
-  workflowJobs: WorkflowJobs,
+  workflowJobs: TimelineJobs,
   showWaitingRunner = true,
 ): ganttJob[] => {
   return filterJobs(workflowJobs).map(
@@ -69,52 +94,44 @@ export const createGanttJobs = (
       if (job.steps === undefined) return undefined;
 
       const section = escapeName(job.name);
-      let firstStep: ganttStep;
+      const completedSteps = filterSteps(job.steps);
+      if (completedSteps.length === 0) return undefined;
+
+      const steps: ganttStep[] = [];
+      let previousTopLevelStepId: ganttStep["id"] | undefined;
 
       const waitingRunnerStep = createWaitingRunnerStep(
         workflow,
         job,
         jobIndex,
       );
-      if (!showWaitingRunner || waitingRunnerStep === undefined) {
-        const rawFirstStep = job.steps.shift();
-        if (rawFirstStep === undefined) return undefined;
-
-        const startJobElapsedSec = diffSec(
-          workflow.run_started_at,
-          job.started_at,
-        );
-        const stepElapsedSec = diffSec(
-          rawFirstStep.started_at,
-          rawFirstStep.completed_at,
-        );
-        firstStep = {
-          name: formatName(rawFirstStep.name, stepElapsedSec),
-          id: `job${jobIndex}-0`,
-          status: convertStepToStatus(
-            rawFirstStep.conclusion as StepConclusion,
-          ),
-          position: formatElapsedTime(startJobElapsedSec),
-          sec: stepElapsedSec,
-        };
-      } else {
-        firstStep = waitingRunnerStep;
+      if (showWaitingRunner && waitingRunnerStep !== undefined) {
+        steps.push(waitingRunnerStep);
+        previousTopLevelStepId = waitingRunnerStep.id;
       }
 
-      const steps = filterSteps(job.steps).map(
-        (step, stepIndex, _steps): ganttStep => {
-          const stepElapsedSec = diffSec(step.started_at, step.completed_at);
-          return {
-            name: formatName(step.name, stepElapsedSec),
-            id: `job${jobIndex}-${stepIndex + 1}`,
-            status: convertStepToStatus(step.conclusion as StepConclusion),
-            position: `after job${jobIndex}-${stepIndex}`,
-            sec: stepElapsedSec,
-          };
-        },
-      );
+      completedSteps.forEach((step) => {
+        const stepElapsedSec = diffSec(step.started_at, step.completed_at);
+        const id = createGanttStepId(jobIndex, steps.length);
+        steps.push({
+          name: formatName(step.name, stepElapsedSec),
+          id,
+          status: convertStepToStatus(step.conclusion as StepConclusion),
+          position: createStepPosition(
+            workflow,
+            job.started_at,
+            step,
+            previousTopLevelStepId,
+          ),
+          sec: stepElapsedSec,
+        });
 
-      return { section, steps: [firstStep, ...steps] };
+        if (step.timelineRowKind !== "composite-child") {
+          previousTopLevelStepId = id;
+        }
+      });
+
+      return { section, steps };
     },
   ).filter((gantJobs): gantJobs is ganttJob => gantJobs !== undefined);
 };
@@ -176,7 +193,7 @@ axisFormat  %H:%M:%S
 
 export const createMermaid = (
   workflow: WorkflowRun,
-  workflowJobs: WorkflowJobs,
+  workflowJobs: TimelineJobs,
   options: GanttOptions,
 ): string => {
   const title = workflow.name ?? "";

--- a/tests/composite.test.ts
+++ b/tests/composite.test.ts
@@ -7,10 +7,13 @@ import {
   WorkflowModel,
 } from "@kesin11/gha-utils";
 import {
+  type CompositeStepInfo,
+  expandJobSteps,
   extractSubSteps,
   identifyCompositeSteps,
   parseLogBlocks,
 } from "../src/composite.ts";
+import type { TimelineStep } from "../src/types.ts";
 
 function makeWorkflowModel(yamlContent: string): WorkflowModel {
   const fileContentResponse: FileContentResponse = {
@@ -364,5 +367,71 @@ Deno.test(extractSubSteps.name, async (t) => {
         },
       ]);
     },
+  );
+});
+
+Deno.test(expandJobSteps.name, () => {
+  const compositeStep: TimelineStep = {
+    name: "Run ./.github/actions/setup",
+    status: "completed",
+    conclusion: "success",
+    number: 2,
+    started_at: "2024-01-15T10:00:05Z",
+    completed_at: "2024-01-15T10:00:15Z",
+  };
+  const normalStep: TimelineStep = {
+    name: "Run deno test",
+    status: "completed",
+    conclusion: "success",
+    number: 3,
+    started_at: "2024-01-15T10:00:15Z",
+    completed_at: "2024-01-15T10:00:18Z",
+  };
+  const steps = [compositeStep, normalStep] as NonNullable<
+    WorkflowJobs[0]["steps"]
+  >;
+  const compositeInfos: CompositeStepInfo[] = [{
+    apiStepIndex: 0,
+    apiStepName: compositeStep.name,
+    usesPath: "./.github/actions/setup",
+    status: compositeStep.status,
+    conclusion: compositeStep.conclusion,
+  }];
+  const compositeStepCounts = new Map([["./.github/actions/setup", 2]]);
+  const logBlocks = [
+    {
+      name: "Run ./.github/actions/setup",
+      startedAt: new Date("2024-01-15T10:00:05Z"),
+    },
+    {
+      name: "Run denoland/setup-deno@v1",
+      startedAt: new Date("2024-01-15T10:00:06Z"),
+    },
+    {
+      name: "Run actions/setup-node@v6",
+      startedAt: new Date("2024-01-15T10:00:10Z"),
+    },
+  ];
+
+  assertEquals(
+    expandJobSteps(steps, compositeInfos, compositeStepCounts, logBlocks),
+    [
+      compositeStep,
+      {
+        ...compositeStep,
+        name: "(sub) denoland/setup-deno@v1",
+        started_at: "2024-01-15T10:00:06.000Z",
+        completed_at: "2024-01-15T10:00:10.000Z",
+        timelineRowKind: "composite-child",
+      },
+      {
+        ...compositeStep,
+        name: "(sub) actions/setup-node@v6",
+        started_at: "2024-01-15T10:00:10.000Z",
+        completed_at: "2024-01-15T10:00:15Z",
+        timelineRowKind: "composite-child",
+      },
+      normalStep,
+    ],
   );
 });

--- a/tests/workflow_gantt_sp.test.ts
+++ b/tests/workflow_gantt_sp.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../src/workflow_gantt.ts";
 import { formatSection } from "../src/format_util.ts";
 import { WorkflowJobs, WorkflowRun } from "@kesin11/gha-utils";
+import type { TimelineJobs } from "../src/types.ts";
 
 const commonWorkflow = {
   "id": 5833450919,
@@ -94,6 +95,88 @@ ${workflowJobs[0].steps![2].name} (0s) :job0-3, after job0-2, 0s
       assertEquals(createMermaid(workflow, workflowJobs, {}), expect);
     },
   );
+
+  await t.step("Keep composite parent and place sub-steps in parallel", () => {
+    const workflow = {
+      ...commonWorkflow,
+      "name": "CI",
+      "run_started_at": "2024-01-15T10:00:00Z",
+    } as unknown as WorkflowRun;
+
+    const workflowJobs = [{
+      "id": 1,
+      "run_id": 5833450919,
+      "workflow_name": "CI",
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2024-01-15T10:00:00Z",
+      "started_at": "2024-01-15T10:00:02Z",
+      "completed_at": "2024-01-15T10:00:14Z",
+      "name": "test",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 1,
+          "started_at": "2024-01-15T10:00:02Z",
+          "completed_at": "2024-01-15T10:00:03Z",
+        },
+        {
+          "name": "Run ./.github/actions/setup",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 2,
+          "started_at": "2024-01-15T10:00:03Z",
+          "completed_at": "2024-01-15T10:00:13Z",
+        },
+        {
+          "name": "(sub) denoland/setup-deno@v1",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 2,
+          "started_at": "2024-01-15T10:00:04Z",
+          "completed_at": "2024-01-15T10:00:06Z",
+          "timelineRowKind": "composite-child",
+        },
+        {
+          "name": "(sub) actions/setup-node@v6",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 2,
+          "started_at": "2024-01-15T10:00:06Z",
+          "completed_at": "2024-01-15T10:00:09Z",
+          "timelineRowKind": "composite-child",
+        },
+        {
+          "name": "Run deno test",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 3,
+          "started_at": "2024-01-15T10:00:13Z",
+          "completed_at": "2024-01-15T10:00:14Z",
+        },
+      ],
+    }] as unknown as TimelineJobs;
+
+    // deno-fmt-ignore
+    const expect = `
+\`\`\`mermaid
+gantt
+title ${workflowJobs[0].workflow_name}
+dateFormat  HH:mm:ss
+axisFormat  %H:%M:%S
+section ${workflowJobs[0].name}
+Waiting for a runner (2s) :active, job0-0, 00:00:00, 2s
+Set up job (1s) :job0-1, after job0-0, 1s
+Run ./.github/actions/setup (10s) :job0-2, after job0-1, 10s
+(sub) denoland/setup-deno@v1 (2s) :job0-3, 00:00:04, 2s
+(sub) actions/setup-node@v6 (3s) :job0-4, 00:00:06, 3s
+Run deno test (1s) :job0-5, after job0-2, 1s
+\`\`\``;
+
+    assertEquals(createMermaid(workflow, workflowJobs, {}), expect);
+  });
 
   await t.step("Retried job", () => {
     const workflow = {

--- a/tests/workflow_gantt_sp.test.ts
+++ b/tests/workflow_gantt_sp.test.ts
@@ -170,8 +170,8 @@ section ${workflowJobs[0].name}
 Waiting for a runner (2s) :active, job0-0, 00:00:00, 2s
 Set up job (1s) :job0-1, after job0-0, 1s
 Run ./.github/actions/setup (10s) :job0-2, after job0-1, 10s
-(sub) denoland/setup-deno@v1 (2s) :job0-3, 00:00:04, 2s
-(sub) actions/setup-node@v6 (3s) :job0-4, 00:00:06, 3s
+(sub) denoland/setup-deno@v1 (2s) :job0-3, after job0-1, 2s
+(sub) actions/setup-node@v6 (3s) :job0-4, after job0-3, 3s
 Run deno test (1s) :job0-5, after job0-2, 1s
 \`\`\``;
 


### PR DESCRIPTION
ref: https://github.com/Kesin11/actions-timeline/issues/37

## Summary
- keep the original composite parent bar when `--expand-composite-actions` is enabled
- render expanded composite child rows in parallel beneath the parent bar
- update tests, README, and verify-composite-expansion skill guidance for the new output

## Verification
- `deno fmt --check`
- `deno lint`
- `deno test`
- `deno task bundle`
- verify-composite-expansion workflow on `kesin11/actions-timeline` run `22953825573` with threshold 5
- verify-composite-expansion workflow on `directus/directus` run `23007299867`

## Notes
- the older `directus/directus` example run `21767232907` currently produced an empty chart even without expansion, so verification used the latest successful `Check` run instead.