### PR TITLE
fix: use `$GITHUB_TOKEN` instead of `$(gh auth token)` in verify-composite skill

### DIFF
--- a/.claude/skills/verify-composite-expansion/SKILL.md
+++ b/.claude/skills/verify-composite-expansion/SKILL.md
@@ -36,13 +36,13 @@ The script performs:
 With composite expansion:
 
 ```bash
-deno run --allow-net --allow-env --allow-write cli.ts --token "$(gh auth token)" --expand-composite-actions=true "https://github.com/{org}/{repo}/actions/runs/{run_id}" -o {repo}_composite.md
+deno run --allow-net --allow-env --allow-write cli.ts --token "$GITHUB_TOKEN" --expand-composite-actions=true "https://github.com/{org}/{repo}/actions/runs/{run_id}" -o {repo}_composite.md
 ```
 
 Without composite expansion:
 
 ```bash
-deno run --allow-net --allow-env --allow-write cli.ts --token "$(gh auth token)" "https://github.com/{org}/{repo}/actions/runs/{run_id}" -o {repo}.md
+deno run --allow-net --allow-env --allow-write cli.ts --token "$GITHUB_TOKEN" "https://github.com/{org}/{repo}/actions/runs/{run_id}" -o {repo}.md
 ```
 
 List jobs:

--- a/.claude/skills/verify-composite-expansion/scripts/verify_composite.sh
+++ b/.claude/skills/verify-composite-expansion/scripts/verify_composite.sh
@@ -32,7 +32,7 @@ mkdir -p "${OUTPUT_DIR}"
 echo "--- [1/5] Generating mermaid WITH composite expansion ---"
 deno run --allow-net --allow-env --allow-write \
   "${REPO_DIR}/cli.ts" \
-  --token "$(gh auth token)" \
+  --token "${GITHUB_TOKEN:?GITHUB_TOKEN is not set. Run: export GITHUB_TOKEN=\$(gh auth token)}" \
   --expand-composite-actions=true \
   "${RUN_URL}" \
   -o "${COMPOSITE_OUT}"
@@ -43,7 +43,7 @@ echo ""
 echo "--- [2/5] Generating mermaid WITHOUT composite expansion ---"
 deno run --allow-net --allow-env --allow-write \
   "${REPO_DIR}/cli.ts" \
-  --token "$(gh auth token)" \
+  --token "${GITHUB_TOKEN:?GITHUB_TOKEN is not set. Run: export GITHUB_TOKEN=\$(gh auth token)}" \
   "${RUN_URL}" \
   -o "${NORMAL_OUT}"
 echo "  -> ${NORMAL_OUT}"


### PR DESCRIPTION
## Summary

- Replace `$(gh auth token)` with `$GITHUB_TOKEN` in the verify-composite-expansion skill
- This allows Claude Code auto-approve to work correctly, since `$(gh auth token)` triggers a shell command substitution that bypasses the approval mechanism
- The shell script now uses `${GITHUB_TOKEN:?...}` to show a clear error message when the variable is not set, guiding users to run `export GITHUB_TOKEN=$(gh auth token)` beforehand

## Test plan

- [ ] Set `export GITHUB_TOKEN=$(gh auth token)` and run the script — verify it works as before
- [ ] Unset `GITHUB_TOKEN` and run the script — verify it exits with a helpful error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)