### PR TITLE
fix: migrate release-drafter.yml to v7 config schema

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,43 +2,39 @@ name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
 categories:
   - title: "BREAKING CHANGES"
-    labels:
-      - "BREAKING CHANGES"
+    semver-increment: "major"
+    when:
+      label: "BREAKING CHANGES"
   - title: "Features"
-    labels:
-      - "feature"
-      - "enhancement"
+    semver-increment: "minor"
+    when:
+      labels:
+        - "feature"
+        - "enhancement"
   - title: "Fixes"
-    labels:
-      - "fix"
-      - "bug"
-      - "security"
+    semver-increment: "patch"
+    when:
+      labels:
+        - "fix"
+        - "bug"
+        - "security"
   - title: "Dependencies"
     collapse-after: 3
-    labels:
-      - "dependencies"
-      - "renovate"
+    when:
+      labels:
+        - "dependencies"
+        - "renovate"
   - title: "Documentation"
-    labels:
-      - "document"
-      - "documentation"
+    when:
+      labels:
+        - "document"
+        - "documentation"
   - title: "Internal improvement"
-    labels:
-      - "ci"
+    when:
+      label: "ci"
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:
-  major:
-    labels:
-      - "BREAKING CHANGES"
-  minor:
-    labels:
-      - "feature"
-      - "enhancement"
-  patch:
-    labels:
-      - "bug"
-      - "security"
   default: patch
 template: |
   ## [v$RESOLVED_VERSION](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION)


### PR DESCRIPTION
## Summary

- Migrate `.github/release-drafter.yml` to the `release-drafter@v7` config schema, following the migration guide in [release-drafter/release-drafter#1558](https://github.com/release-drafter/release-drafter/pull/1558)
- Move each category's `label`/`labels` into a `when` condition
- Move `version-resolver.{major,minor,patch}.labels` into `semver-increment` set directly on the corresponding changelog category, keeping `version-resolver.default: patch` for unmatched PRs
- Resulting version-resolution behavior is unchanged: `BREAKING CHANGES` → major, `feature`/`enhancement` → minor, `fix`/`bug`/`security` → patch (same as before, since `fix` was already falling back to the `patch` default), anything else → patch (default)

Fixes #345

## Test plan

- [x] Validated the migrated YAML against release-drafter's `schema.json` with ajv (passes)
- [x] `deno fmt --check .github/release-drafter.yml`
- [x] `deno test --allow-env` (all existing tests pass — this repo has no automated coverage of the release-drafter config itself)
- [ ] After merge, trigger the `Release` workflow (`workflow_dispatch`) and confirm no deprecation warning annotations appear, e.g. compare against https://github.com/Kesin11/actions-timeline/actions/runs/28520992809
