### PR TITLE
Fix GitHub App token creation in rebundle workflow

### DIFF
--- a/.github/workflows/rebundle.yml
+++ b/.github/workflows/rebundle.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ secrets.BYPASS_APP_ID }}
+          client-id: ${{ secrets.BYPASS_APP_ID }}
           private-key: ${{ secrets.BYPASS_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
## Summary
Updates the GitHub App token creation step in the rebundle workflow to use the correct parameter name for the `actions/create-github-app-token` action.

## Changes
- Changed `app-id` parameter to `client-id` in the `actions/create-github-app-token@v3` step

## Details
The `actions/create-github-app-token` action expects `client-id` as the parameter name, not `app-id`. This change ensures the rebundle workflow can properly authenticate with the GitHub App when creating tokens for automated commits.

https://claude.ai/code/session_01JXyxtQR5su1GAdFvKquRzU