### PR TITLE
timeline: Render parallel steps concurrently

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ GitHub API, and then generates a timeline with
 the GitHub flavored markdown that can visualize mermaid diagrams, the timeline
 is displayed in the run summary page.
 
+Steps declared with the GitHub Actions `parallel` syntax are detected
+automatically. The timeline keeps the `Parallel group` bar and adds `(bg)` rows
+for its child steps at their actual shared start time. Detection is verified
+against the job log; if a log cannot be fetched or matched, that job uses the
+standard timeline layout and emits a warning.
+
+Repo-local composite actions can also be expanded by setting
+`expand-composite-actions: true`. The original composite bar remains visible,
+with its internal steps shown as `(sub)` rows beneath it. Use
+`expand-composite-actions-threshold` to control the minimum duration to expand.
+Nested repo-local composite actions are not currently expanded.
+
 This action is run on post-processing of the job, so you should register this
 action before your build step. If you register this action after your build
 step, the timeline will not include other post-processing steps.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ jobs and steps that occur during a GitHub Actions workflow. By examining the
 timeline, you can quickly identify any issues or bottlenecks in your workflow,
 and make adjustments as needed to improve performance and efficiency.
 
-![Sample screenshot](https://user-images.githubusercontent.com/1324862/268660777-5ee9fffd-6ef7-4960-9632-3589cb7138e1.png)
+![Sample screenshot workflow](https://github.com/user-attachments/assets/03353645-ec6f-4fd6-80b5-19694439393f)
+![Sample screenshot timeline](https://github.com/user-attachments/assets/d92027fc-ded2-4b6e-9ab0-e3923b698ec3)
 
 ## USAGE
 

--- a/README.md
+++ b/README.md
@@ -70,14 +70,11 @@ is displayed in the run summary page.
 Steps declared with the GitHub Actions `parallel` syntax are detected
 automatically. The timeline keeps the `Parallel group` bar and adds `(bg)` rows
 for its child steps at their actual shared start time. Detection is verified
-against the job log; if a log cannot be fetched or matched, that job uses the
-standard timeline layout and emits a warning.
+against the job log.
 
 Repo-local composite actions can also be expanded by setting
 `expand-composite-actions: true`. The original composite bar remains visible,
-with its internal steps shown as `(sub)` rows beneath it. Use
-`expand-composite-actions-threshold` to control the minimum duration to expand.
-Nested repo-local composite actions are not currently expanded.
+with its internal steps shown as `(sub)` rows beneath it. Nested repo-local composite actions are not currently expanded.
 
 This action is run on post-processing of the job, so you should register this
 action before your build step. If you register this action after your build

--- a/cli.ts
+++ b/cli.ts
@@ -2,6 +2,7 @@ import { Command } from "@cliffy/command";
 import { createMermaid } from "./src/workflow_gantt.ts";
 import { expandCompositeSteps } from "./src/composite.ts";
 import { Github, parseWorkflowRunUrl } from "./src/github.ts";
+import { expandParallelSteps } from "./src/parallel.ts";
 
 const { options, args } = await new Command()
   .name("actions-timeline-cli")
@@ -45,11 +46,22 @@ const workflowRun = await client.fetchWorkflowRun(
 );
 const workflowJobs = await client.fetchWorkflowRunJobs(workflowRun);
 
+const parallelResult = await expandParallelSteps(
+  client,
+  workflowRun,
+  workflowJobs,
+);
+parallelResult.warnings.forEach((warning) =>
+  console.warn(
+    `Warning: Parallel steps were not expanded for job "${warning.jobName}" (${warning.jobId}): ${warning.reason}`,
+  )
+);
+
 const jobs = options.expandCompositeActions
-  ? await expandCompositeSteps(client, workflowRun, workflowJobs, {
+  ? await expandCompositeSteps(client, workflowRun, parallelResult.jobs, {
     thresholdSec: options.expandCompositeActionsThreshold,
   })
-  : workflowJobs;
+  : parallelResult.jobs;
 
 const gantt = createMermaid(workflowRun, jobs, {
   showWaitingRunner: options.showWaitingRunner,

--- a/dist/main.js
+++ b/dist/main.js
@@ -1,4 +1,40 @@
 // npm/src/_dnt.polyfills.ts
+function findLastIndex(self, callbackfn, that) {
+  const boundFunc = that === void 0 ? callbackfn : callbackfn.bind(that);
+  let index = self.length - 1;
+  while (index >= 0) {
+    const result = boundFunc(self[index], index, self);
+    if (result) {
+      return index;
+    }
+    index--;
+  }
+  return -1;
+}
+function findLast(self, callbackfn, that) {
+  const index = self.findLastIndex(callbackfn, that);
+  return index === -1 ? void 0 : self[index];
+}
+if (!Array.prototype.findLastIndex) {
+  Array.prototype.findLastIndex = function(callbackfn, that) {
+    return findLastIndex(this, callbackfn, that);
+  };
+}
+if (!Array.prototype.findLast) {
+  Array.prototype.findLast = function(callbackfn, that) {
+    return findLast(this, callbackfn, that);
+  };
+}
+if (!Uint8Array.prototype.findLastIndex) {
+  Uint8Array.prototype.findLastIndex = function(callbackfn, that) {
+    return findLastIndex(this, callbackfn, that);
+  };
+}
+if (!Uint8Array.prototype.findLast) {
+  Uint8Array.prototype.findLast = function(callbackfn, that) {
+    return findLast(this, callbackfn, that);
+  };
+}
 if (!Object.hasOwn) {
   Object.defineProperty(Object, "hasOwn", {
     value: function(object, property) {

--- a/dist/post.js
+++ b/dist/post.js
@@ -34656,11 +34656,15 @@ function identifyCompositeSteps(workflowJobs, workflowModel, thresholdSec) {
     const jobModel = JobModel.match(workflowModel.jobs, job.name);
     if (!jobModel) continue;
     const compositeSteps = [];
+    const occurrenceCounts = /* @__PURE__ */ new Map();
     for (let i = 0; i < job.steps.length; i++) {
       const apiStep = job.steps[i];
       if (/^(Pre Run |Post Run |Pre |Post )/.test(apiStep.name)) continue;
       const stepModel = StepModel.match(jobModel.steps, apiStep.name);
       if (stepModel?.isComposite() && stepModel.raw.uses) {
+        const occurrenceKey = `${apiStep.started_at}\0${stepModel.raw.uses}`;
+        const logHeaderOccurrence = occurrenceCounts.get(occurrenceKey) ?? 0;
+        occurrenceCounts.set(occurrenceKey, logHeaderOccurrence + 1);
         if (diffSec(apiStep.started_at, apiStep.completed_at) < thresholdSec) {
           continue;
         }
@@ -34668,6 +34672,7 @@ function identifyCompositeSteps(workflowJobs, workflowModel, thresholdSec) {
           apiStepIndex: i,
           apiStepName: apiStep.name,
           usesPath: stepModel.raw.uses,
+          logHeaderOccurrence,
           status: apiStep.status,
           conclusion: apiStep.conclusion
         });
@@ -34734,16 +34739,16 @@ function parseLogBlocks(logText) {
   }
   return blocks;
 }
-function extractSubSteps(logBlocks, compositeStartedAt, compositeCompletedAt, compositeStatus, compositeConclusion, compositeUsesPath, expectedStepCount) {
+function extractSubSteps(logBlocks, compositeStartedAt, compositeCompletedAt, compositeStatus, compositeConclusion, compositeUsesPath, expectedStepCount, logHeaderOccurrence = 0) {
   if (expectedStepCount <= 0) {
     return [];
   }
   const compositeStart = new Date(compositeStartedAt).getTime();
   const compositeEnd = new Date(compositeCompletedAt).getTime() + 1e3;
   const pathWithoutPrefix = compositeUsesPath.replace(/^\.\//, "");
-  const headerGlobalIndex = logBlocks.findIndex(
-    (block) => block.startedAt.getTime() >= compositeStart && block.startedAt.getTime() <= compositeEnd && (block.name.includes(compositeUsesPath) || block.name.includes(pathWithoutPrefix))
-  );
+  const headerGlobalIndex = logBlocks.map((block, index) => ({ block, index })).filter(
+    ({ block }) => block.startedAt.getTime() >= compositeStart && block.startedAt.getTime() <= compositeEnd && (block.name.includes(compositeUsesPath) || block.name.includes(pathWithoutPrefix))
+  ).at(logHeaderOccurrence)?.index ?? -1;
   if (headerGlobalIndex < 0) {
     return [];
   }
@@ -34803,7 +34808,8 @@ function expandJobSteps(steps, compositeInfos, compositeStepCounts, logBlocks) {
       apiStep.status,
       apiStep.conclusion,
       compositeInfo.usesPath,
-      expectedStepCount
+      expectedStepCount,
+      compositeInfo.logHeaderOccurrence
     );
     newSteps.push(apiStep);
     if (subSteps.length === 0) {

--- a/dist/post.js
+++ b/dist/post.js
@@ -35434,17 +35434,33 @@ var PARALLEL_GROUP_NAME = "Parallel group";
 var WAITING_MESSAGE = "Waiting for background step(s) to complete:";
 var LOG_TIMESTAMP_PATTERN = String.raw`(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z)`;
 var hasTimestamps = (step) => step.started_at !== null && step.completed_at !== null;
-function identifyParallelGroups(steps) {
+function findParallelCandidateIndexes(steps, parentIndex) {
+  const parent = steps[parentIndex];
+  if (parent.name !== PARALLEL_GROUP_NAME || !hasTimestamps(parent)) return [];
+  const precedingSteps = steps.slice(0, parentIndex);
+  const lastNonChildIndex = precedingSteps.findLastIndex(
+    (step) => !hasTimestamps(step) || step.started_at !== parent.started_at || new Date(step.completed_at).getTime() > new Date(parent.completed_at).getTime()
+  );
+  return precedingSteps.slice(lastNonChildIndex + 1).map((_step, index) => lastNonChildIndex + 1 + index);
+}
+function identifyParallelGroups(steps, markers) {
   return steps.flatMap((parent, parentIndex) => {
     if (parent.name !== PARALLEL_GROUP_NAME || !hasTimestamps(parent)) {
       return [];
     }
-    const precedingSteps = steps.slice(0, parentIndex);
-    const lastNonChildIndex = precedingSteps.findLastIndex(
-      (step) => !hasTimestamps(step) || step.started_at !== parent.started_at || new Date(step.completed_at).getTime() > new Date(parent.completed_at).getTime()
-    );
-    const childIndexes = precedingSteps.slice(lastNonChildIndex + 1).map((_step, index) => lastNonChildIndex + 1 + index);
-    return childIndexes.length > 0 ? [{ parentIndex, childIndexes }] : [];
+    const candidateIndexes = findParallelCandidateIndexes(steps, parentIndex);
+    const parentStart = new Date(parent.started_at).getTime();
+    const parentEnd = new Date(parent.completed_at).getTime() + 1e3;
+    const childIndexes = markers.filter(
+      (marker) => marker.startedAt.getTime() >= parentStart && marker.startedAt.getTime() <= parentEnd
+    ).flatMap(
+      (marker) => candidateIndexes.flatMap((_index, offset) => {
+        const suffix = candidateIndexes.slice(offset);
+        const names = suffix.map((index) => steps[index].name).join(", ");
+        return names === marker.childNames ? [suffix] : [];
+      })
+    ).at(0);
+    return childIndexes !== void 0 ? [{ parentIndex, childIndexes }] : [];
   });
 }
 function parseWaitingMarkers(logText) {
@@ -35476,9 +35492,12 @@ function validateParallelGroups(steps, groups2, logText) {
   return invalidGroup === void 0 ? void 0 : `Could not match API steps for parallel group at step ${invalidGroup.parentIndex + 1} with the job log`;
 }
 function expandParallelJobSteps(steps, logText) {
-  const groups2 = identifyParallelGroups(steps);
   const markers = parseWaitingMarkers(logText);
-  if (groups2.length !== markers.length) {
+  const groups2 = identifyParallelGroups(steps, markers);
+  const apiCandidateCount = steps.filter(
+    (_step, index) => findParallelCandidateIndexes(steps, index).length > 0
+  ).length;
+  if (groups2.length !== markers.length || groups2.length !== apiCandidateCount) {
     return {
       steps,
       warning: "Could not correlate parallel groups between API steps and logs"

--- a/dist/post.js
+++ b/dist/post.js
@@ -34570,7 +34570,9 @@ var JobModel = class {
     this.raw = obj;
   }
   get steps() {
-    return (this.raw.steps ?? []).map((step) => new StepModel(step));
+    return (this.raw.steps ?? []).flatMap(
+      (step) => (step.parallel ?? [step]).map((child) => new StepModel(child))
+    );
   }
   static match(jobModels, rawName) {
     if (jobModels === void 0) return void 0;

--- a/dist/post.js
+++ b/dist/post.js
@@ -34600,7 +34600,7 @@ var StepModel = class {
     if (rawName === "Set up job" || rawName === "Complete job") {
       return void 0;
     }
-    const name = rawName.replace(/^(Pre Run |Post Run |Pre |Run |Post )/, "");
+    const name = rawName.replace(/^\(bg\) /, "").replace(/^(Pre Run |Post Run |Pre |Run |Post )/, "");
     const normalizedName = name.replace(/^\/\.\//, "./");
     const action = normalizedName.split("@")[0];
     for (const stepModel of stepModels) {

--- a/dist/post.js
+++ b/dist/post.js
@@ -34749,8 +34749,13 @@ function extractSubSteps(logBlocks, compositeStartedAt, compositeCompletedAt, co
   const compositeStart = new Date(compositeStartedAt).getTime();
   const compositeEnd = new Date(compositeCompletedAt).getTime() + 1e3;
   const pathWithoutPrefix = compositeUsesPath.replace(/^\.\//, "");
+  const matchesCompositeHeader = (name) => {
+    if (!name.startsWith("Run ")) return false;
+    const loggedPath = name.slice("Run ".length).replace(/^\/\.\//, "./");
+    return loggedPath === compositeUsesPath || loggedPath === pathWithoutPrefix;
+  };
   const headerGlobalIndex = logBlocks.map((block, index) => ({ block, index })).filter(
-    ({ block }) => block.startedAt.getTime() >= compositeStart && block.startedAt.getTime() <= compositeEnd && (block.name.includes(compositeUsesPath) || block.name.includes(pathWithoutPrefix))
+    ({ block }) => block.startedAt.getTime() >= compositeStart && block.startedAt.getTime() <= compositeEnd && matchesCompositeHeader(block.name)
   ).at(logHeaderOccurrence)?.index ?? -1;
   if (headerGlobalIndex < 0) {
     return [];
@@ -35472,11 +35477,11 @@ function validateParallelGroups(steps, groups2, logText) {
 }
 function expandParallelJobSteps(steps, logText) {
   const groups2 = identifyParallelGroups(steps);
-  const parallelGroupCount = steps.filter((step) => step.name === PARALLEL_GROUP_NAME).length;
-  if (groups2.length !== parallelGroupCount) {
+  const markers = parseWaitingMarkers(logText);
+  if (groups2.length !== markers.length) {
     return {
       steps,
-      warning: "Could not identify parallel child steps from API timestamps"
+      warning: "Could not correlate parallel groups between API steps and logs"
     };
   }
   const warning2 = validateParallelGroups(steps, groups2, logText);

--- a/dist/post.js
+++ b/dist/post.js
@@ -26097,6 +26097,42 @@ var require_light = __commonJS({
 });
 
 // npm/src/_dnt.polyfills.ts
+function findLastIndex(self2, callbackfn, that) {
+  const boundFunc = that === void 0 ? callbackfn : callbackfn.bind(that);
+  let index = self2.length - 1;
+  while (index >= 0) {
+    const result = boundFunc(self2[index], index, self2);
+    if (result) {
+      return index;
+    }
+    index--;
+  }
+  return -1;
+}
+function findLast(self2, callbackfn, that) {
+  const index = self2.findLastIndex(callbackfn, that);
+  return index === -1 ? void 0 : self2[index];
+}
+if (!Array.prototype.findLastIndex) {
+  Array.prototype.findLastIndex = function(callbackfn, that) {
+    return findLastIndex(this, callbackfn, that);
+  };
+}
+if (!Array.prototype.findLast) {
+  Array.prototype.findLast = function(callbackfn, that) {
+    return findLast(this, callbackfn, that);
+  };
+}
+if (!Uint8Array.prototype.findLastIndex) {
+  Uint8Array.prototype.findLastIndex = function(callbackfn, that) {
+    return findLastIndex(this, callbackfn, that);
+  };
+}
+if (!Uint8Array.prototype.findLast) {
+  Uint8Array.prototype.findLast = function(callbackfn, that) {
+    return findLast(this, callbackfn, that);
+  };
+}
 if (!Object.hasOwn) {
   Object.defineProperty(Object, "hasOwn", {
     value: function(object, property) {
@@ -26126,6 +26162,19 @@ function toCommandValue(input) {
     return input;
   }
   return JSON.stringify(input);
+}
+function toCommandProperties(annotationProperties) {
+  if (!Object.keys(annotationProperties).length) {
+    return {};
+  }
+  return {
+    title: annotationProperties.title,
+    file: annotationProperties.file,
+    line: annotationProperties.startLine,
+    endLine: annotationProperties.endLine,
+    col: annotationProperties.startColumn,
+    endColumn: annotationProperties.endColumn
+  };
 }
 
 // npm/node_modules/@actions/core/lib/command.js
@@ -26561,6 +26610,9 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
 }
 function debug(message2) {
   issueCommand("debug", {}, message2);
+}
+function warning(message2, properties = {}) {
+  issueCommand("warning", toCommandProperties(properties), message2 instanceof Error ? message2.toString() : message2);
 }
 function info(message2) {
   process.stdout.write(message2 + os3.EOL);
@@ -32181,6 +32233,9 @@ var createCompositeChildPosition = (workflow, step, compositeChildAnchorId, prev
   }
   return `after ${anchorId}`;
 };
+var createParallelStepPosition = (workflow, step) => {
+  return formatElapsedTime(diffSec(workflow.run_started_at, step.started_at));
+};
 var createWaitingRunnerStep = (workflow, job, jobIndex) => {
   const status = "active";
   if (!isString(job.created_at) || !isString(job.started_at)) {
@@ -32233,7 +32288,7 @@ var createGanttJobs = (workflow, workflowJobs, showWaitingRunner = true) => {
           step,
           compositeChildAnchorId,
           previousCompositeChildId
-        ) : createTopLevelStepPosition(
+        ) : step.timelineRowKind === "parallel-parent" || step.timelineRowKind === "parallel-child" ? createParallelStepPosition(workflow, step) : createTopLevelStepPosition(
           workflow,
           jobStartedAt,
           previousTopLevelStepId
@@ -32241,7 +32296,7 @@ var createGanttJobs = (workflow, workflowJobs, showWaitingRunner = true) => {
         steps.push({
           name: formatName(step.name, stepElapsedSec),
           id,
-          status: convertStepToStatus(step.conclusion),
+          status: step.timelineRowKind === "parallel-parent" ? "" : convertStepToStatus(step.conclusion),
           position,
           sec: stepElapsedSec
         });
@@ -32249,6 +32304,7 @@ var createGanttJobs = (workflow, workflowJobs, showWaitingRunner = true) => {
           previousCompositeChildId = id;
           return;
         }
+        if (step.timelineRowKind === "parallel-child") return;
         compositeChildAnchorId = nextStep?.timelineRowKind === "composite-child" ? previousTopLevelStepId : void 0;
         previousCompositeChildId = void 0;
         previousTopLevelStepId = id;
@@ -34654,12 +34710,7 @@ async function fetchCompositeActionStepCount(client, owner, repo, ref, usesPath)
 }
 async function fetchJobLog(client, owner, repo, jobId) {
   try {
-    const res = await client.octokit.actions.downloadJobLogsForWorkflowRun({
-      owner,
-      repo,
-      job_id: jobId
-    });
-    return res.data;
+    return await client.fetchJobLog(owner, repo, jobId);
   } catch (error) {
     console.warn(`Error fetching job log for job ${jobId}:`, error);
     return void 0;
@@ -35237,6 +35288,7 @@ var FileContent = class {
 };
 var Github = class _Github {
   octokitClient;
+  jobLogCache = /* @__PURE__ */ new Map();
   token;
   baseUrl;
   isGHES;
@@ -35289,6 +35341,20 @@ var Github = class _Github {
       per_page: 100
     });
     return res.data.jobs;
+  }
+  fetchJobLog(owner, repo, jobId) {
+    const cached = this.jobLogCache.get(jobId);
+    if (cached) return cached;
+    const log = this.octokitClient.actions.downloadJobLogsForWorkflowRun({
+      owner,
+      repo,
+      job_id: jobId
+    }).then((res) => res.data).catch((error) => {
+      this.jobLogCache.delete(jobId);
+      throw error;
+    });
+    this.jobLogCache.set(jobId, log);
+    return log;
   }
   async fetchWorkflowRun(owner, repo, runId, runAttempt) {
     if (runAttempt !== void 0 && runAttempt > 1) {
@@ -35345,7 +35411,138 @@ var Github = class _Github {
   }
 };
 
+// npm/src/parallel.ts
+var PARALLEL_GROUP_NAME = "Parallel group";
+var WAITING_MESSAGE = "Waiting for background step(s) to complete:";
+var LOG_TIMESTAMP_PATTERN = String.raw`(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z)`;
+var hasTimestamps = (step) => step.started_at !== null && step.completed_at !== null;
+function identifyParallelGroups(steps) {
+  return steps.flatMap((parent, parentIndex) => {
+    if (parent.name !== PARALLEL_GROUP_NAME || !hasTimestamps(parent)) {
+      return [];
+    }
+    const precedingSteps = steps.slice(0, parentIndex);
+    const lastNonChildIndex = precedingSteps.findLastIndex(
+      (step) => !hasTimestamps(step) || step.started_at !== parent.started_at || new Date(step.completed_at).getTime() > new Date(parent.completed_at).getTime()
+    );
+    const childIndexes = precedingSteps.slice(lastNonChildIndex + 1).map((_step, index) => lastNonChildIndex + 1 + index);
+    return childIndexes.length > 0 ? [{ parentIndex, childIndexes }] : [];
+  });
+}
+function parseWaitingMarkers(logText) {
+  const markerRegex = new RegExp(
+    `${LOG_TIMESTAMP_PATTERN}.*${WAITING_MESSAGE.replace(/[()]/g, String.raw`\$&`)}\\s*(.+)$`
+  );
+  return logText.split(/\r?\n/).flatMap((line) => {
+    const match2 = line.match(markerRegex);
+    return match2 ? [{
+      startedAt: new Date(match2[1]),
+      childNames: match2[2].trim()
+    }] : [];
+  });
+}
+function validateParallelGroups(steps, groups2, logText) {
+  const markers = parseWaitingMarkers(logText);
+  const invalidGroup = groups2.find(({ parentIndex, childIndexes }) => {
+    const parent = steps[parentIndex];
+    if (!hasTimestamps(parent)) return true;
+    const expectedNames = childIndexes.map((index) => steps[index].name).join(
+      ", "
+    );
+    const parentStart = new Date(parent.started_at).getTime();
+    const parentEnd = new Date(parent.completed_at).getTime() + 1e3;
+    return !markers.some(
+      (marker) => marker.childNames === expectedNames && marker.startedAt.getTime() >= parentStart && marker.startedAt.getTime() <= parentEnd
+    );
+  });
+  return invalidGroup === void 0 ? void 0 : `Could not match API steps for parallel group at step ${invalidGroup.parentIndex + 1} with the job log`;
+}
+function expandParallelJobSteps(steps, logText) {
+  const groups2 = identifyParallelGroups(steps);
+  const parallelGroupCount = steps.filter((step) => step.name === PARALLEL_GROUP_NAME).length;
+  if (groups2.length !== parallelGroupCount) {
+    return {
+      steps,
+      warning: "Could not identify parallel child steps from API timestamps"
+    };
+  }
+  const warning2 = validateParallelGroups(steps, groups2, logText);
+  if (warning2) return { steps, warning: warning2 };
+  const childIndexes = new Set(groups2.flatMap((group) => group.childIndexes));
+  const groupsByParentIndex = new Map(
+    groups2.map((group) => [group.parentIndex, group])
+  );
+  return {
+    steps: steps.flatMap((step, index) => {
+      if (childIndexes.has(index)) return [];
+      const group = groupsByParentIndex.get(index);
+      if (!group) return [step];
+      return [
+        { ...step, timelineRowKind: "parallel-parent" },
+        ...group.childIndexes.map((childIndex) => ({
+          ...steps[childIndex],
+          name: `(bg) ${steps[childIndex].name}`,
+          timelineRowKind: "parallel-child"
+        }))
+      ];
+    })
+  };
+}
+async function expandParallelSteps(client, workflowRun, workflowJobs) {
+  const jobsWithParallelGroups = workflowJobs.filter(
+    (job) => job.steps?.some((step) => step.name === PARALLEL_GROUP_NAME)
+  );
+  if (jobsWithParallelGroups.length === 0) {
+    return { jobs: workflowJobs, warnings: [] };
+  }
+  const owner = workflowRun.repository.owner.login;
+  const repo = workflowRun.repository.name;
+  const logResults = await Promise.all(
+    jobsWithParallelGroups.map(async (job) => {
+      try {
+        return {
+          jobId: job.id,
+          logText: await client.fetchJobLog(owner, repo, job.id)
+        };
+      } catch (error) {
+        return {
+          jobId: job.id,
+          error: error instanceof Error ? error.message : String(error)
+        };
+      }
+    })
+  );
+  const logsByJobId = new Map(
+    logResults.map((result) => [result.jobId, result])
+  );
+  const warnings = [];
+  const jobs = workflowJobs.map((job) => {
+    if (!job.steps || !logsByJobId.has(job.id)) return job;
+    const logResult = logsByJobId.get(job.id);
+    if (!("logText" in logResult)) {
+      warnings.push({
+        jobId: job.id,
+        jobName: job.name,
+        reason: `Could not download the job log: ${logResult.error}`
+      });
+      return job;
+    }
+    const expanded = expandParallelJobSteps(job.steps, logResult.logText);
+    if (expanded.warning) {
+      warnings.push({
+        jobId: job.id,
+        jobName: job.name,
+        reason: expanded.warning
+      });
+      return job;
+    }
+    return { ...job, steps: expanded.steps };
+  });
+  return { jobs, warnings };
+}
+
 // npm/src/post.ts
+var PARALLEL_FALLBACK_SUMMARY = "Parallel steps could not be expanded for one or more jobs. Those jobs use the standard timeline layout.\n\n";
 var main = async () => {
   const token = getInput("github-token", { required: true });
   const showWaitingRunner = getBooleanInput("show-waiting-runner");
@@ -35368,15 +35565,34 @@ var main = async () => {
   info("Fetch workflow_job...");
   const workflowJobs = await client.fetchWorkflowRunJobs(workflowRun);
   debug(JSON.stringify(workflowJobs, null, 2));
-  let jobs = workflowJobs;
+  info("Expanding parallel steps...");
+  const parallelResult = await expandParallelSteps(
+    client,
+    workflowRun,
+    workflowJobs
+  );
+  parallelResult.warnings.forEach(
+    (item) => warning(
+      `Parallel steps were not expanded for job "${item.jobName}" (${item.jobId}): ${item.reason}`
+    )
+  );
+  let jobs = parallelResult.jobs;
   if (expandCompositeActions) {
     info("Expanding composite action steps...");
-    jobs = await expandCompositeSteps(client, workflowRun, workflowJobs, {
-      thresholdSec: expandCompositeActionsThreshold
-    });
+    jobs = await expandCompositeSteps(
+      client,
+      workflowRun,
+      parallelResult.jobs,
+      {
+        thresholdSec: expandCompositeActionsThreshold
+      }
+    );
   }
   info("Create gantt mermaid diagram...");
   const gantt = createMermaid(workflowRun, jobs, { showWaitingRunner });
+  if (parallelResult.warnings.length > 0) {
+    summary.addRaw(PARALLEL_FALLBACK_SUMMARY);
+  }
   await summary.addRaw(gantt).write();
   debug(gantt);
   info("Complete!");

--- a/dist/post.js
+++ b/dist/post.js
@@ -35494,8 +35494,14 @@ function validateParallelGroups(steps, groups2, logText) {
 function expandParallelJobSteps(steps, logText) {
   const markers = parseWaitingMarkers(logText);
   const groups2 = identifyParallelGroups(steps, markers);
-  const apiCandidateCount = steps.filter(
-    (_step, index) => findParallelCandidateIndexes(steps, index).length > 0
+  const candidateParents = steps.flatMap((_step, parentIndex) => {
+    const childIndexes2 = findParallelCandidateIndexes(steps, parentIndex);
+    return childIndexes2.length > 0 ? [{ parentIndex, childIndexes: childIndexes2 }] : [];
+  });
+  const apiCandidateCount = candidateParents.filter(
+    (candidate) => !candidateParents.some(
+      (other) => other.parentIndex > candidate.parentIndex && other.childIndexes.includes(candidate.parentIndex)
+    )
   ).length;
   if (groups2.length !== markers.length || groups2.length !== apiCandidateCount) {
     return {

--- a/dist/post.js
+++ b/dist/post.js
@@ -32304,7 +32304,11 @@ var createGanttJobs = (workflow, workflowJobs, showWaitingRunner = true) => {
           previousCompositeChildId = id;
           return;
         }
-        if (step.timelineRowKind === "parallel-child") return;
+        if (step.timelineRowKind === "parallel-child") {
+          compositeChildAnchorId = void 0;
+          previousCompositeChildId = void 0;
+          return;
+        }
         compositeChildAnchorId = nextStep?.timelineRowKind === "composite-child" ? previousTopLevelStepId : void 0;
         previousCompositeChildId = void 0;
         previousTopLevelStepId = id;

--- a/dist/post.js
+++ b/dist/post.js
@@ -34604,7 +34604,7 @@ var StepModel = class {
     if (rawName === "Set up job" || rawName === "Complete job") {
       return void 0;
     }
-    const name = rawName.replace(/^\(bg\) /, "").replace(/^(Pre Run |Post Run |Pre |Run |Post )/, "");
+    const name = rawName.replace(/^(Pre Run |Post Run |Pre |Run |Post )/, "");
     const normalizedName = name.replace(/^\/\.\//, "./");
     const action = normalizedName.split("@")[0];
     for (const stepModel of stepModels) {
@@ -34659,8 +34659,9 @@ function identifyCompositeSteps(workflowJobs, workflowModel, thresholdSec) {
     const occurrenceCounts = /* @__PURE__ */ new Map();
     for (let i = 0; i < job.steps.length; i++) {
       const apiStep = job.steps[i];
-      if (/^(Pre Run |Post Run |Pre |Post )/.test(apiStep.name)) continue;
-      const stepModel = StepModel.match(jobModel.steps, apiStep.name);
+      const matchingName = apiStep.timelineOriginalName ?? apiStep.name;
+      if (/^(Pre Run |Post Run |Pre |Post )/.test(matchingName)) continue;
+      const stepModel = StepModel.match(jobModel.steps, matchingName);
       if (stepModel?.isComposite() && stepModel.raw.uses) {
         const occurrenceKey = `${apiStep.started_at}\0${stepModel.raw.uses}`;
         const logHeaderOccurrence = occurrenceCounts.get(occurrenceKey) ?? 0;
@@ -35492,6 +35493,7 @@ function expandParallelJobSteps(steps, logText) {
         ...group.childIndexes.map((childIndex) => ({
           ...steps[childIndex],
           name: `(bg) ${steps[childIndex].name}`,
+          timelineOriginalName: steps[childIndex].name,
           timelineRowKind: "parallel-child"
         }))
       ];

--- a/src/composite.ts
+++ b/src/composite.ts
@@ -18,6 +18,7 @@ export type CompositeStepInfo = {
   apiStepIndex: number;
   apiStepName: string;
   usesPath: string;
+  logHeaderOccurrence: number;
   status: string;
   conclusion: string | null;
 };
@@ -92,12 +93,17 @@ export function identifyCompositeSteps(
     if (!jobModel) continue;
 
     const compositeSteps: CompositeStepInfo[] = [];
+    const occurrenceCounts = new Map<string, number>();
     for (let i = 0; i < job.steps.length; i++) {
       const apiStep = job.steps[i];
       // Skip Pre/Post steps - only expand the main "Run" execution step
       if (/^(Pre Run |Post Run |Pre |Post )/.test(apiStep.name)) continue;
       const stepModel = StepModel.match(jobModel.steps, apiStep.name);
       if (stepModel?.isComposite() && stepModel.raw.uses) {
+        const occurrenceKey = `${apiStep.started_at}\0${stepModel.raw.uses}`;
+        const logHeaderOccurrence = occurrenceCounts.get(occurrenceKey) ?? 0;
+        occurrenceCounts.set(occurrenceKey, logHeaderOccurrence + 1);
+
         if (
           diffSec(apiStep.started_at, apiStep.completed_at) < thresholdSec
         ) {
@@ -108,6 +114,7 @@ export function identifyCompositeSteps(
           apiStepIndex: i,
           apiStepName: apiStep.name,
           usesPath: stepModel.raw.uses,
+          logHeaderOccurrence,
           status: apiStep.status,
           conclusion: apiStep.conclusion,
         });
@@ -215,6 +222,7 @@ export function extractSubSteps(
   compositeConclusion: string | null,
   compositeUsesPath: string,
   expectedStepCount: number,
+  logHeaderOccurrence = 0,
 ): SubStep[] {
   if (expectedStepCount <= 0) {
     return [];
@@ -225,13 +233,15 @@ export function extractSubSteps(
   const compositeEnd = new Date(compositeCompletedAt).getTime() + 1000;
 
   const pathWithoutPrefix = compositeUsesPath.replace(/^\.\//, "");
-  const headerGlobalIndex = logBlocks.findIndex(
-    (block) =>
+  const headerGlobalIndex = logBlocks
+    .map((block, index) => ({ block, index }))
+    .filter(({ block }) =>
       block.startedAt.getTime() >= compositeStart &&
       block.startedAt.getTime() <= compositeEnd &&
       (block.name.includes(compositeUsesPath) ||
-        block.name.includes(pathWithoutPrefix)),
-  );
+        block.name.includes(pathWithoutPrefix))
+    )
+    .at(logHeaderOccurrence)?.index ?? -1;
 
   if (headerGlobalIndex < 0) {
     return [];
@@ -317,6 +327,7 @@ export function expandJobSteps(
       apiStep.conclusion,
       compositeInfo.usesPath,
       expectedStepCount,
+      compositeInfo.logHeaderOccurrence,
     );
 
     newSteps.push(apiStep);

--- a/src/composite.ts
+++ b/src/composite.ts
@@ -96,9 +96,10 @@ export function identifyCompositeSteps(
     const occurrenceCounts = new Map<string, number>();
     for (let i = 0; i < job.steps.length; i++) {
       const apiStep = job.steps[i];
+      const matchingName = apiStep.timelineOriginalName ?? apiStep.name;
       // Skip Pre/Post steps - only expand the main "Run" execution step
-      if (/^(Pre Run |Post Run |Pre |Post )/.test(apiStep.name)) continue;
-      const stepModel = StepModel.match(jobModel.steps, apiStep.name);
+      if (/^(Pre Run |Post Run |Pre |Post )/.test(matchingName)) continue;
+      const stepModel = StepModel.match(jobModel.steps, matchingName);
       if (stepModel?.isComposite() && stepModel.raw.uses) {
         const occurrenceKey = `${apiStep.started_at}\0${stepModel.raw.uses}`;
         const logHeaderOccurrence = occurrenceCounts.get(occurrenceKey) ?? 0;

--- a/src/composite.ts
+++ b/src/composite.ts
@@ -2,7 +2,7 @@ import { decodeBase64 } from "@std/encoding";
 import { parse as parseYaml } from "@std/yaml";
 import { diffSec } from "./format_util.ts";
 import type { TimelineJobs, TimelineStep } from "./types.ts";
-import { Github, type WorkflowJobs, type WorkflowRun } from "./github.ts";
+import { Github, type WorkflowRun } from "./github.ts";
 import {
   type CompositeAction,
   JobModel,
@@ -79,7 +79,7 @@ async function fetchWorkflowModel(
 
 // Identify composite steps in each job by matching API steps against the YAML model.
 export function identifyCompositeSteps(
-  workflowJobs: WorkflowJobs,
+  workflowJobs: TimelineJobs,
   workflowModel: WorkflowModel,
   thresholdSec: number,
 ): Map<number, CompositeStepInfo[]> {
@@ -178,12 +178,7 @@ async function fetchJobLog(
   jobId: number,
 ): Promise<string | undefined> {
   try {
-    const res = await client.octokit.actions.downloadJobLogsForWorkflowRun({
-      owner,
-      repo,
-      job_id: jobId,
-    });
-    return res.data as unknown as string;
+    return await client.fetchJobLog(owner, repo, jobId);
   } catch (error) {
     console.warn(`Error fetching job log for job ${jobId}:`, error);
     return undefined;
@@ -287,7 +282,7 @@ export function extractSubSteps(
 }
 
 export function expandJobSteps(
-  steps: NonNullable<WorkflowJobs[0]["steps"]>,
+  steps: NonNullable<TimelineJobs[0]["steps"]>,
   compositeInfos: CompositeStepInfo[],
   compositeStepCounts: Map<string, number>,
   logBlocks: LogBlock[],
@@ -355,7 +350,7 @@ export function expandJobSteps(
 export async function expandCompositeSteps(
   client: Github,
   workflowRun: WorkflowRun,
-  workflowJobs: WorkflowJobs,
+  workflowJobs: TimelineJobs,
   options: ExpandCompositeOptions = {},
 ): Promise<TimelineJobs> {
   const thresholdSec = options.thresholdSec ?? 20;

--- a/src/composite.ts
+++ b/src/composite.ts
@@ -234,13 +234,18 @@ export function extractSubSteps(
   const compositeEnd = new Date(compositeCompletedAt).getTime() + 1000;
 
   const pathWithoutPrefix = compositeUsesPath.replace(/^\.\//, "");
+  const matchesCompositeHeader = (name: string): boolean => {
+    if (!name.startsWith("Run ")) return false;
+    const loggedPath = name.slice("Run ".length).replace(/^\/\.\//, "./");
+    return loggedPath === compositeUsesPath ||
+      loggedPath === pathWithoutPrefix;
+  };
   const headerGlobalIndex = logBlocks
     .map((block, index) => ({ block, index }))
     .filter(({ block }) =>
       block.startedAt.getTime() >= compositeStart &&
       block.startedAt.getTime() <= compositeEnd &&
-      (block.name.includes(compositeUsesPath) ||
-        block.name.includes(pathWithoutPrefix))
+      matchesCompositeHeader(block.name)
     )
     .at(logHeaderOccurrence)?.index ?? -1;
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -127,6 +127,7 @@ type ThrottleRequestOptions = {
 
 export class Github {
   private readonly octokitClient: Octokit;
+  private readonly jobLogCache = new Map<number, Promise<string>>();
   token?: string;
   baseUrl: string;
   isGHES: boolean;
@@ -196,6 +197,24 @@ export class Github {
         per_page: 100,
       });
     return res.data.jobs as WorkflowJobs;
+  }
+
+  fetchJobLog(owner: string, repo: string, jobId: number): Promise<string> {
+    const cached = this.jobLogCache.get(jobId);
+    if (cached) return cached;
+
+    const log = this.octokitClient.actions.downloadJobLogsForWorkflowRun({
+      owner,
+      repo,
+      job_id: jobId,
+    })
+      .then((res) => res.data as unknown as string)
+      .catch((error) => {
+        this.jobLogCache.delete(jobId);
+        throw error;
+      });
+    this.jobLogCache.set(jobId, log);
+    return log;
   }
 
   async fetchWorkflowRun(

--- a/src/parallel.ts
+++ b/src/parallel.ts
@@ -145,9 +145,16 @@ export function expandParallelJobSteps(
 ): { steps: TimelineStep[]; warning?: string } {
   const markers = parseWaitingMarkers(logText);
   const groups = identifyParallelGroups(steps, markers);
+  const candidateParents = steps.flatMap((_step, parentIndex) => {
+    const childIndexes = findParallelCandidateIndexes(steps, parentIndex);
+    return childIndexes.length > 0 ? [{ parentIndex, childIndexes }] : [];
+  });
   const apiCandidateCount =
-    steps.filter((_step, index) =>
-      findParallelCandidateIndexes(steps, index).length > 0
+    candidateParents.filter((candidate) =>
+      !candidateParents.some((other) =>
+        other.parentIndex > candidate.parentIndex &&
+        other.childIndexes.includes(candidate.parentIndex)
+      )
     ).length;
   if (
     groups.length !== markers.length ||

--- a/src/parallel.ts
+++ b/src/parallel.ts
@@ -1,0 +1,213 @@
+import type { WorkflowJobs, WorkflowJobStep, WorkflowRun } from "./github.ts";
+import { Github } from "./github.ts";
+import type { TimelineJobs, TimelineStep } from "./types.ts";
+
+const PARALLEL_GROUP_NAME = "Parallel group";
+const WAITING_MESSAGE = "Waiting for background step(s) to complete:";
+const LOG_TIMESTAMP_PATTERN = String
+  .raw`(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z)`;
+
+type ParallelGroup = {
+  parentIndex: number;
+  childIndexes: number[];
+};
+
+type JobLogResult =
+  | { jobId: number; logText: string }
+  | { jobId: number; error: string };
+
+export type ParallelExpansionWarning = {
+  jobId: number;
+  jobName: string;
+  reason: string;
+};
+
+export type ParallelExpansionResult = {
+  jobs: TimelineJobs;
+  warnings: ParallelExpansionWarning[];
+};
+
+const hasTimestamps = (
+  step: WorkflowJobStep,
+): step is WorkflowJobStep & {
+  started_at: string;
+  completed_at: string;
+} => step.started_at !== null && step.completed_at !== null;
+
+function identifyParallelGroups(
+  steps: NonNullable<WorkflowJobs[number]["steps"]>,
+): ParallelGroup[] {
+  return steps.flatMap((parent, parentIndex): ParallelGroup[] => {
+    if (parent.name !== PARALLEL_GROUP_NAME || !hasTimestamps(parent)) {
+      return [];
+    }
+
+    const precedingSteps = steps.slice(0, parentIndex);
+    const lastNonChildIndex = precedingSteps.findLastIndex((step) =>
+      !hasTimestamps(step) ||
+      step.started_at !== parent.started_at ||
+      new Date(step.completed_at).getTime() >
+        new Date(parent.completed_at).getTime()
+    );
+    const childIndexes = precedingSteps
+      .slice(lastNonChildIndex + 1)
+      .map((_step, index) => lastNonChildIndex + 1 + index);
+
+    return childIndexes.length > 0 ? [{ parentIndex, childIndexes }] : [];
+  });
+}
+
+function parseWaitingMarkers(
+  logText: string,
+): Array<{ startedAt: Date; childNames: string }> {
+  const markerRegex = new RegExp(
+    `${LOG_TIMESTAMP_PATTERN}.*${
+      WAITING_MESSAGE.replace(/[()]/g, String.raw`\$&`)
+    }\\s*(.+)$`,
+  );
+
+  return logText.split(/\r?\n/).flatMap((line) => {
+    const match = line.match(markerRegex);
+    return match
+      ? [{
+        startedAt: new Date(match[1]),
+        childNames: match[2].trim(),
+      }]
+      : [];
+  });
+}
+
+function validateParallelGroups(
+  steps: NonNullable<WorkflowJobs[number]["steps"]>,
+  groups: ParallelGroup[],
+  logText: string,
+): string | undefined {
+  const markers = parseWaitingMarkers(logText);
+
+  const invalidGroup = groups.find(({ parentIndex, childIndexes }) => {
+    const parent = steps[parentIndex];
+    if (!hasTimestamps(parent)) return true;
+
+    const expectedNames = childIndexes.map((index) => steps[index].name).join(
+      ", ",
+    );
+    const parentStart = new Date(parent.started_at).getTime();
+    const parentEnd = new Date(parent.completed_at).getTime() + 1000;
+
+    return !markers.some((marker) =>
+      marker.childNames === expectedNames &&
+      marker.startedAt.getTime() >= parentStart &&
+      marker.startedAt.getTime() <= parentEnd
+    );
+  });
+
+  return invalidGroup === undefined
+    ? undefined
+    : `Could not match API steps for parallel group at step ${
+      invalidGroup.parentIndex + 1
+    } with the job log`;
+}
+
+export function expandParallelJobSteps(
+  steps: NonNullable<WorkflowJobs[number]["steps"]>,
+  logText: string,
+): { steps: TimelineStep[]; warning?: string } {
+  const groups = identifyParallelGroups(steps);
+  const parallelGroupCount =
+    steps.filter((step) => step.name === PARALLEL_GROUP_NAME).length;
+  if (groups.length !== parallelGroupCount) {
+    return {
+      steps,
+      warning: "Could not identify parallel child steps from API timestamps",
+    };
+  }
+
+  const warning = validateParallelGroups(steps, groups, logText);
+  if (warning) return { steps, warning };
+
+  const childIndexes = new Set(groups.flatMap((group) => group.childIndexes));
+  const groupsByParentIndex = new Map(
+    groups.map((group) => [group.parentIndex, group]),
+  );
+
+  return {
+    steps: steps.flatMap((step, index): TimelineStep[] => {
+      if (childIndexes.has(index)) return [];
+
+      const group = groupsByParentIndex.get(index);
+      if (!group) return [step];
+
+      return [
+        { ...step, timelineRowKind: "parallel-parent" },
+        ...group.childIndexes.map((childIndex) => ({
+          ...steps[childIndex],
+          name: `(bg) ${steps[childIndex].name}`,
+          timelineRowKind: "parallel-child" as const,
+        })),
+      ];
+    }),
+  };
+}
+
+export async function expandParallelSteps(
+  client: Pick<Github, "fetchJobLog">,
+  workflowRun: WorkflowRun,
+  workflowJobs: WorkflowJobs,
+): Promise<ParallelExpansionResult> {
+  const jobsWithParallelGroups = workflowJobs.filter((job) =>
+    job.steps?.some((step) => step.name === PARALLEL_GROUP_NAME)
+  );
+  if (jobsWithParallelGroups.length === 0) {
+    return { jobs: workflowJobs, warnings: [] };
+  }
+
+  const owner = workflowRun.repository.owner.login;
+  const repo = workflowRun.repository.name;
+  const logResults: JobLogResult[] = await Promise.all(
+    jobsWithParallelGroups.map(async (job): Promise<JobLogResult> => {
+      try {
+        return {
+          jobId: job.id,
+          logText: await client.fetchJobLog(owner, repo, job.id),
+        };
+      } catch (error) {
+        return {
+          jobId: job.id,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    }),
+  );
+  const logsByJobId = new Map(
+    logResults.map((result) => [result.jobId, result]),
+  );
+  const warnings: ParallelExpansionWarning[] = [];
+
+  const jobs: TimelineJobs = workflowJobs.map((job) => {
+    if (!job.steps || !logsByJobId.has(job.id)) return job;
+
+    const logResult = logsByJobId.get(job.id)!;
+    if (!("logText" in logResult)) {
+      warnings.push({
+        jobId: job.id,
+        jobName: job.name,
+        reason: `Could not download the job log: ${logResult.error}`,
+      });
+      return job;
+    }
+
+    const expanded = expandParallelJobSteps(job.steps, logResult.logText);
+    if (expanded.warning) {
+      warnings.push({
+        jobId: job.id,
+        jobName: job.name,
+        reason: expanded.warning,
+      });
+      return job;
+    }
+
+    return { ...job, steps: expanded.steps };
+  });
+
+  return { jobs, warnings };
+}

--- a/src/parallel.ts
+++ b/src/parallel.ts
@@ -142,6 +142,7 @@ export function expandParallelJobSteps(
         ...group.childIndexes.map((childIndex) => ({
           ...steps[childIndex],
           name: `(bg) ${steps[childIndex].name}`,
+          timelineOriginalName: steps[childIndex].name,
           timelineRowKind: "parallel-child" as const,
         })),
       ];

--- a/src/parallel.ts
+++ b/src/parallel.ts
@@ -113,12 +113,11 @@ export function expandParallelJobSteps(
   logText: string,
 ): { steps: TimelineStep[]; warning?: string } {
   const groups = identifyParallelGroups(steps);
-  const parallelGroupCount =
-    steps.filter((step) => step.name === PARALLEL_GROUP_NAME).length;
-  if (groups.length !== parallelGroupCount) {
+  const markers = parseWaitingMarkers(logText);
+  if (groups.length !== markers.length) {
     return {
       steps,
-      warning: "Could not identify parallel child steps from API timestamps",
+      warning: "Could not correlate parallel groups between API steps and logs",
     };
   }
 

--- a/src/parallel.ts
+++ b/src/parallel.ts
@@ -12,6 +12,11 @@ type ParallelGroup = {
   childIndexes: number[];
 };
 
+type WaitingMarker = {
+  startedAt: Date;
+  childNames: string;
+};
+
 type JobLogResult =
   | { jobId: number; logText: string }
   | { jobId: number; error: string };
@@ -34,32 +39,58 @@ const hasTimestamps = (
   completed_at: string;
 } => step.started_at !== null && step.completed_at !== null;
 
+function findParallelCandidateIndexes(
+  steps: NonNullable<WorkflowJobs[number]["steps"]>,
+  parentIndex: number,
+): number[] {
+  const parent = steps[parentIndex];
+  if (parent.name !== PARALLEL_GROUP_NAME || !hasTimestamps(parent)) return [];
+
+  const precedingSteps = steps.slice(0, parentIndex);
+  const lastNonChildIndex = precedingSteps.findLastIndex((step) =>
+    !hasTimestamps(step) ||
+    step.started_at !== parent.started_at ||
+    new Date(step.completed_at).getTime() >
+      new Date(parent.completed_at).getTime()
+  );
+  return precedingSteps
+    .slice(lastNonChildIndex + 1)
+    .map((_step, index) => lastNonChildIndex + 1 + index);
+}
+
 function identifyParallelGroups(
   steps: NonNullable<WorkflowJobs[number]["steps"]>,
+  markers: WaitingMarker[],
 ): ParallelGroup[] {
   return steps.flatMap((parent, parentIndex): ParallelGroup[] => {
     if (parent.name !== PARALLEL_GROUP_NAME || !hasTimestamps(parent)) {
       return [];
     }
 
-    const precedingSteps = steps.slice(0, parentIndex);
-    const lastNonChildIndex = precedingSteps.findLastIndex((step) =>
-      !hasTimestamps(step) ||
-      step.started_at !== parent.started_at ||
-      new Date(step.completed_at).getTime() >
-        new Date(parent.completed_at).getTime()
-    );
-    const childIndexes = precedingSteps
-      .slice(lastNonChildIndex + 1)
-      .map((_step, index) => lastNonChildIndex + 1 + index);
+    const candidateIndexes = findParallelCandidateIndexes(steps, parentIndex);
+    const parentStart = new Date(parent.started_at).getTime();
+    const parentEnd = new Date(parent.completed_at).getTime() + 1000;
+    const childIndexes = markers
+      .filter((marker) =>
+        marker.startedAt.getTime() >= parentStart &&
+        marker.startedAt.getTime() <= parentEnd
+      )
+      .flatMap((marker) =>
+        candidateIndexes.flatMap((_index, offset) => {
+          const suffix = candidateIndexes.slice(offset);
+          const names = suffix.map((index) => steps[index].name).join(", ");
+          return names === marker.childNames ? [suffix] : [];
+        })
+      )
+      .at(0);
 
-    return childIndexes.length > 0 ? [{ parentIndex, childIndexes }] : [];
+    return childIndexes !== undefined ? [{ parentIndex, childIndexes }] : [];
   });
 }
 
 function parseWaitingMarkers(
   logText: string,
-): Array<{ startedAt: Date; childNames: string }> {
+): WaitingMarker[] {
   const markerRegex = new RegExp(
     `${LOG_TIMESTAMP_PATTERN}.*${
       WAITING_MESSAGE.replace(/[()]/g, String.raw`\$&`)
@@ -112,9 +143,16 @@ export function expandParallelJobSteps(
   steps: NonNullable<WorkflowJobs[number]["steps"]>,
   logText: string,
 ): { steps: TimelineStep[]; warning?: string } {
-  const groups = identifyParallelGroups(steps);
   const markers = parseWaitingMarkers(logText);
-  if (groups.length !== markers.length) {
+  const groups = identifyParallelGroups(steps, markers);
+  const apiCandidateCount =
+    steps.filter((_step, index) =>
+      findParallelCandidateIndexes(steps, index).length > 0
+    ).length;
+  if (
+    groups.length !== markers.length ||
+    groups.length !== apiCandidateCount
+  ) {
     return {
       steps,
       warning: "Could not correlate parallel groups between API steps and logs",

--- a/src/post.ts
+++ b/src/post.ts
@@ -1,10 +1,21 @@
 import { setTimeout } from "node:timers/promises";
 import process from "node:process";
-import { debug, getBooleanInput, getInput, info, summary } from "@actions/core";
+import {
+  debug,
+  getBooleanInput,
+  getInput,
+  info,
+  summary,
+  warning,
+} from "@actions/core";
 import * as github from "@actions/github";
 import { createMermaid } from "./workflow_gantt.ts";
 import { expandCompositeSteps } from "./composite.ts";
 import { Github } from "./github.ts";
+import { expandParallelSteps } from "./parallel.ts";
+
+const PARALLEL_FALLBACK_SUMMARY =
+  "Parallel steps could not be expanded for one or more jobs. Those jobs use the standard timeline layout.\n\n";
 
 const main = async () => {
   const token = getInput("github-token", { required: true });
@@ -36,16 +47,36 @@ const main = async () => {
 
   debug(JSON.stringify(workflowJobs, null, 2));
 
-  let jobs = workflowJobs;
+  info("Expanding parallel steps...");
+  const parallelResult = await expandParallelSteps(
+    client,
+    workflowRun,
+    workflowJobs,
+  );
+  parallelResult.warnings.forEach((item) =>
+    warning(
+      `Parallel steps were not expanded for job "${item.jobName}" (${item.jobId}): ${item.reason}`,
+    )
+  );
+
+  let jobs = parallelResult.jobs;
   if (expandCompositeActions) {
     info("Expanding composite action steps...");
-    jobs = await expandCompositeSteps(client, workflowRun, workflowJobs, {
-      thresholdSec: expandCompositeActionsThreshold,
-    });
+    jobs = await expandCompositeSteps(
+      client,
+      workflowRun,
+      parallelResult.jobs,
+      {
+        thresholdSec: expandCompositeActionsThreshold,
+      },
+    );
   }
 
   info("Create gantt mermaid diagram...");
   const gantt = createMermaid(workflowRun, jobs, { showWaitingRunner });
+  if (parallelResult.warnings.length > 0) {
+    summary.addRaw(PARALLEL_FALLBACK_SUMMARY);
+  }
   await summary.addRaw(gantt).write();
   debug(gantt);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,10 +3,13 @@ import type { WorkflowJobs } from "./github.ts";
 export type TimelineStep =
   & NonNullable<WorkflowJobs[number]["steps"]>[number]
   & {
-    timelineRowKind?: "composite-child";
+    timelineRowKind?:
+      | "composite-child"
+      | "parallel-parent"
+      | "parallel-child";
   };
 
-export type TimelineJob = Omit<WorkflowJobs[number], "steps"> & {
+export type TimelineJob = WorkflowJobs[number] & {
   steps?: TimelineStep[];
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import type { WorkflowJobs } from "./github.ts";
 export type TimelineStep =
   & NonNullable<WorkflowJobs[number]["steps"]>[number]
   & {
+    timelineOriginalName?: string;
     timelineRowKind?:
       | "composite-child"
       | "parallel-parent"

--- a/src/workflow_file.ts
+++ b/src/workflow_file.ts
@@ -60,7 +60,9 @@ export class JobModel {
   }
 
   get steps(): StepModel[] {
-    return (this.raw.steps ?? []).map((step) => new StepModel(step));
+    return (this.raw.steps ?? []).flatMap((step) =>
+      (step.parallel ?? [step]).map((child) => new StepModel(child))
+    );
   }
 
   static match(
@@ -103,6 +105,7 @@ export type Step = {
   uses?: string;
   name?: string;
   run?: string;
+  parallel?: Step[];
   with?: Record<string, unknown>;
   [key: string]: unknown;
 };

--- a/src/workflow_file.ts
+++ b/src/workflow_file.ts
@@ -132,7 +132,9 @@ export class StepModel {
       return undefined;
     }
 
-    const name = rawName.replace(/^(Pre Run |Post Run |Pre |Run |Post )/, "");
+    const name = rawName
+      .replace(/^\(bg\) /, "")
+      .replace(/^(Pre Run |Post Run |Pre |Run |Post )/, "");
     // Normalize: GitHub API sometimes adds extra "/" before "./" for local actions
     const normalizedName = name.replace(/^\/\.\//, "./");
     const action = normalizedName.split("@")[0];

--- a/src/workflow_file.ts
+++ b/src/workflow_file.ts
@@ -132,9 +132,7 @@ export class StepModel {
       return undefined;
     }
 
-    const name = rawName
-      .replace(/^\(bg\) /, "")
-      .replace(/^(Pre Run |Post Run |Pre |Run |Post )/, "");
+    const name = rawName.replace(/^(Pre Run |Post Run |Pre |Run |Post )/, "");
     // Normalize: GitHub API sometimes adds extra "/" before "./" for local actions
     const normalizedName = name.replace(/^\/\.\//, "./");
     const action = normalizedName.split("@")[0];

--- a/src/workflow_gantt.ts
+++ b/src/workflow_gantt.ts
@@ -171,7 +171,11 @@ export const createGanttJobs = (
           previousCompositeChildId = id;
           return;
         }
-        if (step.timelineRowKind === "parallel-child") return;
+        if (step.timelineRowKind === "parallel-child") {
+          compositeChildAnchorId = undefined;
+          previousCompositeChildId = undefined;
+          return;
+        }
 
         compositeChildAnchorId = nextStep?.timelineRowKind === "composite-child"
           ? previousTopLevelStepId

--- a/src/workflow_gantt.ts
+++ b/src/workflow_gantt.ts
@@ -65,6 +65,13 @@ const createCompositeChildPosition = (
   return `after ${anchorId}`;
 };
 
+const createParallelStepPosition = (
+  workflow: WorkflowRun,
+  step: TimelineStep,
+): string => {
+  return formatElapsedTime(diffSec(workflow.run_started_at, step.started_at));
+};
+
 const createWaitingRunnerStep = (
   workflow: WorkflowRun,
   job: TimelineJobs[0],
@@ -141,6 +148,9 @@ export const createGanttJobs = (
             compositeChildAnchorId,
             previousCompositeChildId,
           )
+          : step.timelineRowKind === "parallel-parent" ||
+              step.timelineRowKind === "parallel-child"
+          ? createParallelStepPosition(workflow, step)
           : createTopLevelStepPosition(
             workflow,
             jobStartedAt,
@@ -150,7 +160,9 @@ export const createGanttJobs = (
         steps.push({
           name: formatName(step.name, stepElapsedSec),
           id,
-          status: convertStepToStatus(step.conclusion as StepConclusion),
+          status: step.timelineRowKind === "parallel-parent"
+            ? ""
+            : convertStepToStatus(step.conclusion as StepConclusion),
           position,
           sec: stepElapsedSec,
         });
@@ -159,6 +171,7 @@ export const createGanttJobs = (
           previousCompositeChildId = id;
           return;
         }
+        if (step.timelineRowKind === "parallel-child") return;
 
         compositeChildAnchorId = nextStep?.timelineRowKind === "composite-child"
           ? previousTopLevelStepId

--- a/tests/composite.test.ts
+++ b/tests/composite.test.ts
@@ -422,6 +422,45 @@ Deno.test(extractSubSteps.name, async (t) => {
     }]);
   });
 
+  await t.step("does not match a composite path prefix", () => {
+    const prefixBlocks = [
+      {
+        name: "Run ./.github/actions/setup-node",
+        startedAt: new Date("2024-01-15T10:00:05.100Z"),
+      },
+      {
+        name: "Run echo node",
+        startedAt: new Date("2024-01-15T10:00:06Z"),
+      },
+      {
+        name: "Run ./.github/actions/setup",
+        startedAt: new Date("2024-01-15T10:00:05.200Z"),
+      },
+      {
+        name: "Run echo setup",
+        startedAt: new Date("2024-01-15T10:00:07Z"),
+      },
+    ];
+
+    const subSteps = extractSubSteps(
+      prefixBlocks,
+      "2024-01-15T10:00:05Z",
+      "2024-01-15T10:00:15Z",
+      "completed",
+      "success",
+      "./.github/actions/setup",
+      1,
+    );
+
+    assertEquals(subSteps, [{
+      name: "echo setup",
+      started_at: "2024-01-15T10:00:07.000Z",
+      completed_at: "2024-01-15T10:00:15Z",
+      status: "completed",
+      conclusion: "success",
+    }]);
+  });
+
   await t.step(
     "includes auxiliary blocks from uses actions (e.g. Environment details)",
     () => {

--- a/tests/composite.test.ts
+++ b/tests/composite.test.ts
@@ -80,6 +80,7 @@ Deno.test(identifyCompositeSteps.name, async (t) => {
     assertEquals(result.size, 1);
     assertEquals(result.get(1)?.length, 1);
     assertEquals(result.get(1)?.[0].usesPath, "./.github/actions/setup");
+    assertEquals(result.get(1)?.[0].logHeaderOccurrence, 0);
   });
 
   await t.step("includes step with duration above threshold", () => {
@@ -93,6 +94,28 @@ Deno.test(identifyCompositeSteps.name, async (t) => {
       thresholdSec,
     );
     assertEquals(result.size, 1);
+  });
+
+  await t.step("numbers concurrent invocations of the same action", () => {
+    const workflowJobs = makeWorkflowJobs(
+      "2024-01-15T10:00:00Z",
+      "2024-01-15T10:00:30Z",
+    );
+    workflowJobs[0].steps!.push({
+      ...workflowJobs[0].steps![0],
+      number: 2,
+    });
+
+    const result = identifyCompositeSteps(
+      workflowJobs,
+      workflowModel,
+      thresholdSec,
+    );
+
+    assertEquals(
+      result.get(1)?.map((step) => step.logHeaderOccurrence),
+      [0, 1],
+    );
   });
 
   await t.step("excludes step with duration below threshold", () => {
@@ -303,6 +326,46 @@ Deno.test(extractSubSteps.name, async (t) => {
     assertEquals(subSteps, []);
   });
 
+  await t.step("selects repeated concurrent headers by occurrence", () => {
+    const repeatedBlocks = [
+      {
+        name: "Run ./.github/actions/setup",
+        startedAt: new Date("2024-01-15T10:00:05.100Z"),
+      },
+      {
+        name: "Run echo first",
+        startedAt: new Date("2024-01-15T10:00:05.150Z"),
+      },
+      {
+        name: "Run ./.github/actions/setup",
+        startedAt: new Date("2024-01-15T10:00:05.200Z"),
+      },
+      {
+        name: "Run echo second",
+        startedAt: new Date("2024-01-15T10:00:07Z"),
+      },
+    ];
+
+    const subSteps = extractSubSteps(
+      repeatedBlocks,
+      "2024-01-15T10:00:05Z",
+      "2024-01-15T10:00:15Z",
+      "completed",
+      "success",
+      "./.github/actions/setup",
+      1,
+      1,
+    );
+
+    assertEquals(subSteps, [{
+      name: "echo second",
+      started_at: "2024-01-15T10:00:07.000Z",
+      completed_at: "2024-01-15T10:00:15Z",
+      status: "completed",
+      conclusion: "success",
+    }]);
+  });
+
   await t.step(
     "includes auxiliary blocks from uses actions (e.g. Environment details)",
     () => {
@@ -394,6 +457,7 @@ Deno.test(expandJobSteps.name, () => {
     apiStepIndex: 0,
     apiStepName: compositeStep.name,
     usesPath: "./.github/actions/setup",
+    logHeaderOccurrence: 0,
     status: compositeStep.status,
     conclusion: compositeStep.conclusion,
   }];

--- a/tests/composite.test.ts
+++ b/tests/composite.test.ts
@@ -119,6 +119,16 @@ Deno.test(identifyCompositeSteps.name, async (t) => {
   });
 
   await t.step("matches a parallel child by its original API name", () => {
+    const parallelWorkflowModel = makeWorkflowModel(`
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - parallel:
+          - uses: ./.github/actions/setup
+          - run: echo hello
+`);
     const workflowJobs = makeWorkflowJobs(
       "2024-01-15T10:00:00Z",
       "2024-01-15T10:00:30Z",
@@ -132,7 +142,7 @@ Deno.test(identifyCompositeSteps.name, async (t) => {
 
     const result = identifyCompositeSteps(
       workflowJobs,
-      workflowModel,
+      parallelWorkflowModel,
       thresholdSec,
     );
 

--- a/tests/composite.test.ts
+++ b/tests/composite.test.ts
@@ -13,7 +13,7 @@ import {
   identifyCompositeSteps,
   parseLogBlocks,
 } from "../src/composite.ts";
-import type { TimelineStep } from "../src/types.ts";
+import type { TimelineJobs, TimelineStep } from "../src/types.ts";
 
 function makeWorkflowModel(yamlContent: string): WorkflowModel {
   const fileContentResponse: FileContentResponse = {
@@ -116,6 +116,52 @@ Deno.test(identifyCompositeSteps.name, async (t) => {
       result.get(1)?.map((step) => step.logHeaderOccurrence),
       [0, 1],
     );
+  });
+
+  await t.step("matches a parallel child by its original API name", () => {
+    const workflowJobs = makeWorkflowJobs(
+      "2024-01-15T10:00:00Z",
+      "2024-01-15T10:00:30Z",
+    ) as TimelineJobs;
+    workflowJobs[0].steps![0] = {
+      ...workflowJobs[0].steps![0],
+      name: "(bg) Run ./.github/actions/setup",
+      timelineOriginalName: "Run ./.github/actions/setup",
+      timelineRowKind: "parallel-child",
+    };
+
+    const result = identifyCompositeSteps(
+      workflowJobs,
+      workflowModel,
+      thresholdSec,
+    );
+
+    assertEquals(result.get(1)?.[0].usesPath, "./.github/actions/setup");
+  });
+
+  await t.step("preserves a user-defined name beginning with (bg)", () => {
+    const namedWorkflowModel = makeWorkflowModel(`
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: (bg) setup
+        uses: ./.github/actions/setup
+`);
+    const workflowJobs = makeWorkflowJobs(
+      "2024-01-15T10:00:00Z",
+      "2024-01-15T10:00:30Z",
+    );
+    workflowJobs[0].steps![0].name = "(bg) setup";
+
+    const result = identifyCompositeSteps(
+      workflowJobs,
+      namedWorkflowModel,
+      thresholdSec,
+    );
+
+    assertEquals(result.get(1)?.[0].usesPath, "./.github/actions/setup");
   });
 
   await t.step("excludes step with duration below threshold", () => {

--- a/tests/fixture/parallel_datafusion.ts
+++ b/tests/fixture/parallel_datafusion.ts
@@ -1,0 +1,80 @@
+import type { WorkflowJobs, WorkflowRun } from "../../src/github.ts";
+
+export const workflow = {
+  id: 30673491143,
+  name: "Datafusion extended tests",
+  run_started_at: "2026-07-31T23:39:40Z",
+  repository: {
+    name: "datafusion",
+    owner: { login: "apache" },
+  },
+} as WorkflowRun;
+
+export const jobs = [{
+  id: 91295892639,
+  name: "Run sqllogictests with the sqlite test suite",
+  status: "completed",
+  conclusion: "success",
+  created_at: "2026-07-31T23:39:41Z",
+  started_at: "2026-07-31T23:40:02Z",
+  completed_at: "2026-07-31T23:41:25Z",
+  steps: [
+    {
+      number: 1,
+      name: "Set up job",
+      status: "completed",
+      conclusion: "success",
+      started_at: "2026-07-31T23:40:02Z",
+      completed_at: "2026-07-31T23:40:03Z",
+    },
+    {
+      number: 4,
+      name: "Run runs-on/action@4e5f7239",
+      status: "completed",
+      conclusion: "success",
+      started_at: "2026-07-31T23:40:03Z",
+      completed_at: "2026-07-31T23:40:19Z",
+    },
+    {
+      number: 5,
+      name: "Run actions/checkout@3d3c42e5",
+      status: "completed",
+      conclusion: "success",
+      started_at: "2026-07-31T23:40:19Z",
+      completed_at: "2026-07-31T23:41:24Z",
+    },
+    {
+      number: 6,
+      name: "Install protobuf compiler",
+      status: "completed",
+      conclusion: "success",
+      started_at: "2026-07-31T23:40:19Z",
+      completed_at: "2026-07-31T23:40:22Z",
+    },
+    {
+      number: 7,
+      name: "Parallel group",
+      status: "completed",
+      conclusion: "success",
+      started_at: "2026-07-31T23:40:19Z",
+      completed_at: "2026-07-31T23:41:24Z",
+    },
+    {
+      number: 8,
+      name: "Run sqllogictest",
+      status: "completed",
+      conclusion: "success",
+      started_at: "2026-07-31T23:41:24Z",
+      completed_at: "2026-07-31T23:41:25Z",
+    },
+  ],
+}] as WorkflowJobs;
+
+export const log = `
+2026-07-31T23:40:19.1000000Z ##[group]Run actions/checkout@3d3c42e5
+2026-07-31T23:40:19.2000000Z ##[group]Run apt-get install protobuf-compiler
+2026-07-31T23:40:19.3000000Z Waiting for background step(s) to complete: Run actions/checkout@3d3c42e5, Install protobuf compiler
+2026-07-31T23:41:24.1000000Z Finished waiting for background step(s).
+2026-07-31T23:41:24.2000000Z   Run actions/checkout@3d3c42e5: Succeeded
+2026-07-31T23:41:24.3000000Z   Install protobuf compiler: Succeeded
+`;

--- a/tests/fixture/parallel_nuxt.ts
+++ b/tests/fixture/parallel_nuxt.ts
@@ -1,0 +1,80 @@
+import type { WorkflowJobs, WorkflowRun } from "../../src/github.ts";
+
+export const workflow = {
+  id: 30668200410,
+  name: "ci",
+  run_started_at: "2026-07-31T21:54:41Z",
+  repository: {
+    name: "nuxt",
+    owner: { login: "nuxt" },
+  },
+} as WorkflowRun;
+
+export const jobs = [{
+  id: 91280033726,
+  name: "typecheck (ubuntu-24.04-arm, bundler)",
+  status: "completed",
+  conclusion: "success",
+  created_at: "2026-07-31T21:54:52Z",
+  started_at: "2026-07-31T21:54:56Z",
+  completed_at: "2026-07-31T21:57:31Z",
+  steps: [
+    {
+      number: 1,
+      name: "Set up job",
+      status: "completed",
+      conclusion: "success",
+      started_at: "2026-07-31T21:54:56Z",
+      completed_at: "2026-07-31T21:54:57Z",
+    },
+    {
+      number: 3,
+      name: "Run voidzero-dev/setup-vp@250f29ce",
+      status: "completed",
+      conclusion: "success",
+      started_at: "2026-07-31T21:54:57Z",
+      completed_at: "2026-07-31T21:55:20Z",
+    },
+    {
+      number: 4,
+      name: "Test (types)",
+      status: "completed",
+      conclusion: "success",
+      started_at: "2026-07-31T21:55:20Z",
+      completed_at: "2026-07-31T21:56:21Z",
+    },
+    {
+      number: 5,
+      name: "Typecheck (docs)",
+      status: "completed",
+      conclusion: "success",
+      started_at: "2026-07-31T21:55:20Z",
+      completed_at: "2026-07-31T21:57:30Z",
+    },
+    {
+      number: 6,
+      name: "Parallel group",
+      status: "completed",
+      conclusion: "success",
+      started_at: "2026-07-31T21:55:20Z",
+      completed_at: "2026-07-31T21:57:30Z",
+    },
+    {
+      number: 7,
+      name: "Cancel workflow on failure",
+      status: "completed",
+      conclusion: "skipped",
+      started_at: "2026-07-31T21:57:30Z",
+      completed_at: "2026-07-31T21:57:30Z",
+    },
+  ],
+}] as WorkflowJobs;
+
+export const log = `
+2026-07-31T21:55:20.7598592Z ##[group]Run vp run test:types
+2026-07-31T21:55:20.7795459Z ##[group]Run vp run typecheck:docs
+2026-07-31T21:55:20.7920202Z Waiting for background step(s) to complete: Test (types), Typecheck (docs)
+2026-07-31T21:57:30.3086853Z Finished waiting for background step(s).
+2026-07-31T21:57:30.3087533Z   Test (types): Succeeded
+2026-07-31T21:57:30.3087840Z   Typecheck (docs): Succeeded
+`;

--- a/tests/parallel.test.ts
+++ b/tests/parallel.test.ts
@@ -140,6 +140,7 @@ Run sqllogictest (1s) :job0-6, after job0-3, 1s
         apiStepIndex: compositeIndex,
         apiStepName: compositeStep.name,
         usesPath: "./.github/actions/setup",
+        logHeaderOccurrence: 0,
         status: compositeStep.status,
         conclusion: compositeStep.conclusion,
       }],

--- a/tests/parallel.test.ts
+++ b/tests/parallel.test.ts
@@ -83,9 +83,38 @@ Run sqllogictest (1s) :job0-6, after job0-3, 1s
   await t.step("keeps the original steps when the log does not match", () => {
     const result = expandParallelJobSteps(nuxtJobs[0].steps!, "");
     assertEquals(result.steps, nuxtJobs[0].steps);
-    assertStringIncludes(
-      result.warning!,
-      "Could not match API steps for parallel group",
+    assertEquals(
+      result.warning,
+      "Could not correlate parallel groups between API steps and logs",
+    );
+  });
+
+  await t.step("ignores a user step named Parallel group", () => {
+    const userStep = {
+      ...nuxtJobs[0].steps![0],
+      name: "Parallel group",
+      started_at: "2026-07-31T21:57:31Z",
+      completed_at: "2026-07-31T21:57:32Z",
+    };
+    const steps = [...nuxtJobs[0].steps!, userStep];
+
+    const result = expandParallelJobSteps(steps, nuxtLog);
+
+    assertEquals(result.warning, undefined);
+    assertEquals(result.steps.at(-1), userStep);
+  });
+
+  await t.step("falls back when a logged group has no API candidate", () => {
+    const steps = nuxtJobs[0].steps!.filter((step) =>
+      step.name !== "Parallel group"
+    );
+
+    const result = expandParallelJobSteps(steps, nuxtLog);
+
+    assertEquals(result.steps, steps);
+    assertEquals(
+      result.warning,
+      "Could not correlate parallel groups between API steps and logs",
     );
   });
 

--- a/tests/parallel.test.ts
+++ b/tests/parallel.test.ts
@@ -149,6 +149,33 @@ Run sqllogictest (1s) :job0-6, after job0-3, 1s
     );
   });
 
+  await t.step("allows a parallel child named Parallel group", () => {
+    const steps = nuxtJobs[0].steps!.map((step) =>
+      step.name === "Typecheck (docs)"
+        ? { ...step, name: "Parallel group" }
+        : step
+    );
+    const log = nuxtLog.replace(
+      /Test \(types\), Typecheck \(docs\)/,
+      "Test (types), Parallel group",
+    );
+
+    const result = expandParallelJobSteps(steps, log);
+
+    assertEquals(result.warning, undefined);
+    assertEquals(
+      result.steps.map((step) => step.name),
+      [
+        "Set up job",
+        "Run voidzero-dev/setup-vp@250f29ce",
+        "Parallel group",
+        "(bg) Test (types)",
+        "(bg) Parallel group",
+        "Cancel workflow on failure",
+      ],
+    );
+  });
+
   await t.step("styles only a failed child as critical", () => {
     const failedSteps = nuxtJobs[0].steps!.map((step) =>
       step.name === "Test (types)" || step.name === "Parallel group"

--- a/tests/parallel.test.ts
+++ b/tests/parallel.test.ts
@@ -118,6 +118,37 @@ Run sqllogictest (1s) :job0-6, after job0-3, 1s
     );
   });
 
+  await t.step("excludes a preceding fast step from parallel children", () => {
+    const fastStep = {
+      ...nuxtJobs[0].steps![0],
+      number: 3,
+      name: "Fast top-level step",
+      started_at: "2026-07-31T21:55:20Z",
+      completed_at: "2026-07-31T21:55:20Z",
+    };
+    const steps = [
+      ...nuxtJobs[0].steps!.slice(0, 2),
+      fastStep,
+      ...nuxtJobs[0].steps!.slice(2),
+    ];
+
+    const result = expandParallelJobSteps(steps, nuxtLog);
+
+    assertEquals(result.warning, undefined);
+    assertEquals(
+      result.steps.map((step) => step.name),
+      [
+        "Set up job",
+        "Run voidzero-dev/setup-vp@250f29ce",
+        "Fast top-level step",
+        "Parallel group",
+        "(bg) Test (types)",
+        "(bg) Typecheck (docs)",
+        "Cancel workflow on failure",
+      ],
+    );
+  });
+
   await t.step("styles only a failed child as critical", () => {
     const failedSteps = nuxtJobs[0].steps!.map((step) =>
       step.name === "Test (types)" || step.name === "Parallel group"

--- a/tests/parallel.test.ts
+++ b/tests/parallel.test.ts
@@ -15,6 +15,7 @@ import {
   log as nuxtLog,
   workflow as nuxtWorkflow,
 } from "./fixture/parallel_nuxt.ts";
+import { StepModel } from "../src/workflow_file.ts";
 
 Deno.test(expandParallelJobSteps.name, async (t) => {
   await t.step("renders the Nuxt typecheck steps in parallel", () => {
@@ -112,23 +113,29 @@ Run sqllogictest (1s) :job0-6, after job0-3, 1s
   });
 
   await t.step("preserves parallel rows during composite expansion", () => {
-    const parallelResult = expandParallelJobSteps(
-      nuxtJobs[0].steps!,
-      nuxtLog,
+    const compositeName = "Run ./.github/actions/setup";
+    const stepsWithComposite = datafusionJobs[0].steps!.map((step) =>
+      step.name === "Run actions/checkout@3d3c42e5"
+        ? { ...step, name: compositeName }
+        : step
     );
-    const compositeStep = {
-      number: 8,
-      name: "Run ./.github/actions/setup",
-      status: "completed",
-      conclusion: "success",
-      started_at: "2026-07-31T21:57:30Z",
-      completed_at: "2026-07-31T21:57:40Z",
-    };
-    const steps = [...parallelResult.steps, compositeStep];
-    const compositeIndex = steps.length - 1;
+    const parallelResult = expandParallelJobSteps(
+      stepsWithComposite,
+      datafusionLog.replace(
+        /Run actions\/checkout@3d3c42e5/g,
+        compositeName,
+      ),
+    );
+    const compositeIndex = parallelResult.steps.findIndex((step) =>
+      StepModel.match(
+        [new StepModel({ uses: "./.github/actions/setup" })],
+        step.name,
+      )?.isComposite()
+    );
+    const compositeStep = parallelResult.steps[compositeIndex];
 
     const expanded = expandJobSteps(
-      steps,
+      parallelResult.steps,
       [{
         apiStepIndex: compositeIndex,
         apiStepName: compositeStep.name,
@@ -140,11 +147,11 @@ Run sqllogictest (1s) :job0-6, after job0-3, 1s
       [
         {
           name: "Run ./.github/actions/setup",
-          startedAt: new Date("2026-07-31T21:57:30Z"),
+          startedAt: new Date("2026-07-31T23:40:19Z"),
         },
         {
           name: "Run echo setup",
-          startedAt: new Date("2026-07-31T21:57:31Z"),
+          startedAt: new Date("2026-07-31T23:40:20Z"),
         },
       ],
     );
@@ -153,13 +160,12 @@ Run sqllogictest (1s) :job0-6, after job0-3, 1s
       expanded.map((step) => [step.name, step.timelineRowKind]),
       [
         ["Set up job", undefined],
-        ["Run voidzero-dev/setup-vp@250f29ce", undefined],
+        ["Run runs-on/action@4e5f7239", undefined],
         ["Parallel group", "parallel-parent"],
-        ["(bg) Test (types)", "parallel-child"],
-        ["(bg) Typecheck (docs)", "parallel-child"],
-        ["Cancel workflow on failure", undefined],
-        ["Run ./.github/actions/setup", undefined],
+        ["(bg) Run ./.github/actions/setup", "parallel-child"],
         ["(sub) echo setup", "composite-child"],
+        ["(bg) Install protobuf compiler", "parallel-child"],
+        ["Run sqllogictest", undefined],
       ],
     );
   });

--- a/tests/parallel.test.ts
+++ b/tests/parallel.test.ts
@@ -15,7 +15,6 @@ import {
   log as nuxtLog,
   workflow as nuxtWorkflow,
 } from "./fixture/parallel_nuxt.ts";
-import { StepModel } from "../src/workflow_file.ts";
 
 Deno.test(expandParallelJobSteps.name, async (t) => {
   await t.step("renders the Nuxt typecheck steps in parallel", () => {
@@ -126,11 +125,8 @@ Run sqllogictest (1s) :job0-6, after job0-3, 1s
         compositeName,
       ),
     );
-    const compositeIndex = parallelResult.steps.findIndex((step) =>
-      StepModel.match(
-        [new StepModel({ uses: "./.github/actions/setup" })],
-        step.name,
-      )?.isComposite()
+    const compositeIndex = parallelResult.steps.findIndex(
+      (step) => step.timelineOriginalName === compositeName,
     );
     const compositeStep = parallelResult.steps[compositeIndex];
 

--- a/tests/parallel.test.ts
+++ b/tests/parallel.test.ts
@@ -169,6 +169,52 @@ Run sqllogictest (1s) :job0-6, after job0-3, 1s
       ],
     );
   });
+
+  await t.step("starts each background composite child independently", () => {
+    const steps = [
+      {
+        ...datafusionJobs[0].steps![4],
+        timelineRowKind: "parallel-parent" as const,
+      },
+      {
+        ...datafusionJobs[0].steps![2],
+        name: "(bg) Run ./.github/actions/setup-one",
+        timelineRowKind: "parallel-child" as const,
+      },
+      {
+        ...datafusionJobs[0].steps![2],
+        name: "(sub) setup one",
+        started_at: "2026-07-31T23:40:20Z",
+        completed_at: "2026-07-31T23:40:21Z",
+        timelineRowKind: "composite-child" as const,
+      },
+      {
+        ...datafusionJobs[0].steps![3],
+        name: "(bg) Run ./.github/actions/setup-two",
+        timelineRowKind: "parallel-child" as const,
+      },
+      {
+        ...datafusionJobs[0].steps![3],
+        name: "(sub) setup two",
+        started_at: "2026-07-31T23:40:20Z",
+        completed_at: "2026-07-31T23:40:22Z",
+        timelineRowKind: "composite-child" as const,
+      },
+    ];
+    const mermaid = createMermaid(datafusionWorkflow, [{
+      ...datafusionJobs[0],
+      steps,
+    }], { showWaitingRunner: false });
+
+    assertStringIncludes(
+      mermaid,
+      "(sub) setup one (1s) :job0-2, 00:00:40, 1s",
+    );
+    assertStringIncludes(
+      mermaid,
+      "(sub) setup two (2s) :job0-4, 00:00:40, 2s",
+    );
+  });
 });
 
 Deno.test(expandParallelSteps.name, async () => {

--- a/tests/parallel.test.ts
+++ b/tests/parallel.test.ts
@@ -1,0 +1,203 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { expandJobSteps } from "../src/composite.ts";
+import { createMermaid } from "../src/workflow_gantt.ts";
+import {
+  expandParallelJobSteps,
+  expandParallelSteps,
+} from "../src/parallel.ts";
+import {
+  jobs as datafusionJobs,
+  log as datafusionLog,
+  workflow as datafusionWorkflow,
+} from "./fixture/parallel_datafusion.ts";
+import {
+  jobs as nuxtJobs,
+  log as nuxtLog,
+  workflow as nuxtWorkflow,
+} from "./fixture/parallel_nuxt.ts";
+
+Deno.test(expandParallelJobSteps.name, async (t) => {
+  await t.step("renders the Nuxt typecheck steps in parallel", () => {
+    const result = expandParallelJobSteps(nuxtJobs[0].steps!, nuxtLog);
+    assertEquals(result.warning, undefined);
+
+    // deno-fmt-ignore
+    const expected = `
+\`\`\`mermaid
+gantt
+title ci
+dateFormat  HH:mm:ss
+axisFormat  %H:%M:%S
+section typecheck (ubuntu-24.04-arm, bundler)
+Waiting for a runner (4s) :active, job0-0, 00:00:11, 4s
+Set up job (1s) :job0-1, after job0-0, 1s
+Run voidzero-dev/setup-vp@250f29ce (23s) :job0-2, after job0-1, 23s
+Parallel group (2m10s) :job0-3, 00:00:39, 130s
+(bg) Test (types) (1m1s) :job0-4, 00:00:39, 61s
+(bg) Typecheck (docs) (2m10s) :job0-5, 00:00:39, 130s
+Cancel workflow on failure (0s) :done, job0-6, after job0-3, 0s
+\`\`\``;
+
+    assertEquals(
+      createMermaid(nuxtWorkflow, [{
+        ...nuxtJobs[0],
+        steps: result.steps,
+      }], {}),
+      expected,
+    );
+  });
+
+  await t.step("renders action and run children in parallel", () => {
+    const result = expandParallelJobSteps(
+      datafusionJobs[0].steps!,
+      datafusionLog,
+    );
+    assertEquals(result.warning, undefined);
+
+    // deno-fmt-ignore
+    const expected = `
+\`\`\`mermaid
+gantt
+title Datafusion extended tests
+dateFormat  HH:mm:ss
+axisFormat  %H:%M:%S
+section Run sqllogictests with the sqlite test suite
+Waiting for a runner (21s) :active, job0-0, 00:00:01, 21s
+Set up job (1s) :job0-1, after job0-0, 1s
+Run runs-on/action@4e5f7239 (16s) :job0-2, after job0-1, 16s
+Parallel group (1m5s) :job0-3, 00:00:39, 65s
+(bg) Run actions/checkout@3d3c42e5 (1m5s) :job0-4, 00:00:39, 65s
+(bg) Install protobuf compiler (3s) :job0-5, 00:00:39, 3s
+Run sqllogictest (1s) :job0-6, after job0-3, 1s
+\`\`\``;
+
+    assertEquals(
+      createMermaid(datafusionWorkflow, [{
+        ...datafusionJobs[0],
+        steps: result.steps,
+      }], {}),
+      expected,
+    );
+  });
+
+  await t.step("keeps the original steps when the log does not match", () => {
+    const result = expandParallelJobSteps(nuxtJobs[0].steps!, "");
+    assertEquals(result.steps, nuxtJobs[0].steps);
+    assertStringIncludes(
+      result.warning!,
+      "Could not match API steps for parallel group",
+    );
+  });
+
+  await t.step("styles only a failed child as critical", () => {
+    const failedSteps = nuxtJobs[0].steps!.map((step) =>
+      step.name === "Test (types)" || step.name === "Parallel group"
+        ? { ...step, conclusion: "failure" }
+        : step
+    );
+    const result = expandParallelJobSteps(failedSteps, nuxtLog);
+    const mermaid = createMermaid(nuxtWorkflow, [{
+      ...nuxtJobs[0],
+      steps: result.steps,
+    }], {});
+
+    assertStringIncludes(
+      mermaid,
+      "Parallel group (2m10s) :job0-3, 00:00:39, 130s",
+    );
+    assertStringIncludes(
+      mermaid,
+      "(bg) Test (types) (1m1s) :crit, job0-4, 00:00:39, 61s",
+    );
+  });
+
+  await t.step("preserves parallel rows during composite expansion", () => {
+    const parallelResult = expandParallelJobSteps(
+      nuxtJobs[0].steps!,
+      nuxtLog,
+    );
+    const compositeStep = {
+      number: 8,
+      name: "Run ./.github/actions/setup",
+      status: "completed",
+      conclusion: "success",
+      started_at: "2026-07-31T21:57:30Z",
+      completed_at: "2026-07-31T21:57:40Z",
+    };
+    const steps = [...parallelResult.steps, compositeStep];
+    const compositeIndex = steps.length - 1;
+
+    const expanded = expandJobSteps(
+      steps,
+      [{
+        apiStepIndex: compositeIndex,
+        apiStepName: compositeStep.name,
+        usesPath: "./.github/actions/setup",
+        status: compositeStep.status,
+        conclusion: compositeStep.conclusion,
+      }],
+      new Map([["./.github/actions/setup", 1]]),
+      [
+        {
+          name: "Run ./.github/actions/setup",
+          startedAt: new Date("2026-07-31T21:57:30Z"),
+        },
+        {
+          name: "Run echo setup",
+          startedAt: new Date("2026-07-31T21:57:31Z"),
+        },
+      ],
+    );
+
+    assertEquals(
+      expanded.map((step) => [step.name, step.timelineRowKind]),
+      [
+        ["Set up job", undefined],
+        ["Run voidzero-dev/setup-vp@250f29ce", undefined],
+        ["Parallel group", "parallel-parent"],
+        ["(bg) Test (types)", "parallel-child"],
+        ["(bg) Typecheck (docs)", "parallel-child"],
+        ["Cancel workflow on failure", undefined],
+        ["Run ./.github/actions/setup", undefined],
+        ["(sub) echo setup", "composite-child"],
+      ],
+    );
+  });
+});
+
+Deno.test(expandParallelSteps.name, async () => {
+  const jobs = [...nuxtJobs, {
+    ...datafusionJobs[0],
+    id: 2,
+    name: "log unavailable",
+  }];
+  const client = {
+    fetchJobLog: (_owner: string, _repo: string, jobId: number) =>
+      jobId === 2
+        ? Promise.reject(new Error("HTTP 403"))
+        : Promise.resolve(nuxtLog),
+  };
+
+  const result = await expandParallelSteps(client, nuxtWorkflow, jobs);
+
+  assertEquals(
+    result.jobs[0].steps?.map((step) => [
+      step.name,
+      step.timelineRowKind,
+    ]),
+    [
+      ["Set up job", undefined],
+      ["Run voidzero-dev/setup-vp@250f29ce", undefined],
+      ["Parallel group", "parallel-parent"],
+      ["(bg) Test (types)", "parallel-child"],
+      ["(bg) Typecheck (docs)", "parallel-child"],
+      ["Cancel workflow on failure", undefined],
+    ],
+  );
+  assertEquals(result.jobs[1], jobs[1]);
+  assertEquals(result.warnings, [{
+    jobId: 2,
+    jobName: "log unavailable",
+    reason: "Could not download the job log: HTTP 403",
+  }]);
+});


### PR DESCRIPTION
## Summary

- detect GitHub Actions parallel step groups by correlating workflow job timestamps with background-step log markers
- derive exact child boundaries from the marker's ordered names, avoiding second-precision timestamp collisions
- keep the `Parallel group` parent while rendering API-ordered `(bg)` child rows at their real shared start time
- preserve child status styling and anchor subsequent steps to the parent group
- preserve composite expansion for background composite actions, including multiple and repeated concurrent composites
- avoid user display-name and prefix-overlapping composite-path collisions
- keep original API names as metadata so display prefixes never affect workflow matching
- fall back to the existing layout per job when logs cannot be verified, with CLI warnings and Action summary/annotation warnings
- cache job log downloads across parallel and composite expansion
- document parallel and composite expansion behavior in README's **How it works** section

## Validation

- `deno fmt --check`
- `deno lint`
- `deno test` (14 tests, 60 steps)
- `deno task bundle`
- compared generated Mermaid output with job logs from `Kesin11/actions-timeline`, `nuxt/nuxt`, and `apache/datafusion`
- completed a rubber-duck self-review and addressed all findings
- addressed all Copilot review findings through repeated rereviews