### PR TITLE
composite: Skip synthetic parallel parents

### DIFF
--- a/dist/post.js
+++ b/dist/post.js
@@ -34661,6 +34661,7 @@ function identifyCompositeSteps(workflowJobs, workflowModel, thresholdSec) {
     const occurrenceCounts = /* @__PURE__ */ new Map();
     for (let i = 0; i < job.steps.length; i++) {
       const apiStep = job.steps[i];
+      if (apiStep.timelineRowKind === "parallel-parent") continue;
       const matchingName = apiStep.timelineOriginalName ?? apiStep.name;
       if (/^(Pre Run |Post Run |Pre |Post )/.test(matchingName)) continue;
       const stepModel = StepModel.match(jobModel.steps, matchingName);

--- a/src/composite.ts
+++ b/src/composite.ts
@@ -96,6 +96,7 @@ export function identifyCompositeSteps(
     const occurrenceCounts = new Map<string, number>();
     for (let i = 0; i < job.steps.length; i++) {
       const apiStep = job.steps[i];
+      if (apiStep.timelineRowKind === "parallel-parent") continue;
       const matchingName = apiStep.timelineOriginalName ?? apiStep.name;
       // Skip Pre/Post steps - only expand the main "Run" execution step
       if (/^(Pre Run |Post Run |Pre |Post )/.test(matchingName)) continue;

--- a/tests/composite.test.ts
+++ b/tests/composite.test.ts
@@ -149,6 +149,55 @@ jobs:
     assertEquals(result.get(1)?.[0].usesPath, "./.github/actions/setup");
   });
 
+  await t.step("does not match a synthetic parallel parent", () => {
+    const parallelWorkflowModel = makeWorkflowModel(`
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - parallel:
+          - name: Parallel group
+            uses: ./.github/actions/setup
+          - run: echo hello
+`);
+    const workflowJobs = makeWorkflowJobs(
+      "2024-01-15T10:00:00Z",
+      "2024-01-15T10:00:30Z",
+    ) as TimelineJobs;
+    const child = workflowJobs[0].steps![0];
+    workflowJobs[0].steps = [
+      {
+        ...child,
+        name: "Parallel group",
+        timelineRowKind: "parallel-parent",
+      },
+      {
+        ...child,
+        name: "(bg) Parallel group",
+        timelineOriginalName: "Parallel group",
+        timelineRowKind: "parallel-child",
+      },
+    ];
+
+    const result = identifyCompositeSteps(
+      workflowJobs,
+      parallelWorkflowModel,
+      thresholdSec,
+    );
+
+    assertEquals(
+      result.get(1)?.map((step) => ({
+        apiStepIndex: step.apiStepIndex,
+        logHeaderOccurrence: step.logHeaderOccurrence,
+      })),
+      [{
+        apiStepIndex: 1,
+        logHeaderOccurrence: 0,
+      }],
+    );
+  });
+
   await t.step("preserves a user-defined name beginning with (bg)", () => {
     const namedWorkflowModel = makeWorkflowModel(`
 on: push


### PR DESCRIPTION
## Summary

- exclude synthetic `parallel-parent` timeline rows from composite workflow matching
- ensure a background local composite named `Parallel group` remains the only matched invocation and receives occurrence zero
- add regression coverage using a real `parallel:` workflow model

This follows up on the final Copilot review observation posted after #362 had already merged.

## Validation

- `deno fmt --check`
- `deno lint`
- `deno test` (14 tests, 62 steps)
- rubber-duck self-review completed with no blocking findings