### PR TITLE
Support workflow_run completed events

### DIFF
--- a/dist/post.js
+++ b/dist/post.js
@@ -35686,6 +35686,34 @@ async function expandParallelSteps(client, workflowRun, workflowJobs) {
   return { jobs, warnings };
 }
 
+// npm/src/workflow_run.ts
+function isPositiveInteger(value) {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+function resolveWorkflowRunTarget(currentRun, event) {
+  if (event.eventName !== "workflow_run" || event.action !== "completed") {
+    return currentRun;
+  }
+  const runId = event.workflowRun?.id;
+  if (!isPositiveInteger(runId)) {
+    throw new Error(
+      "workflow_run.completed payload is missing a valid workflow run id"
+    );
+  }
+  const runAttempt = event.workflowRun?.runAttempt ?? 1;
+  if (!isPositiveInteger(runAttempt)) {
+    throw new Error(
+      "workflow_run.completed payload has an invalid workflow run attempt"
+    );
+  }
+  return {
+    owner: currentRun.owner,
+    repo: currentRun.repo,
+    runId,
+    runAttempt
+  };
+}
+
 // npm/src/post.ts
 var PARALLEL_FALLBACK_SUMMARY = "Parallel steps could not be expanded for one or more jobs. Those jobs use the standard timeline layout.\n\n";
 var main = async () => {
@@ -35700,11 +35728,27 @@ var main = async () => {
   await (0, import_promises.setTimeout)(1e3);
   info("Fetch workflow...");
   const runAttempt = import_node_process.default.env.GITHUB_RUN_ATTEMPT ? Number(import_node_process.default.env.GITHUB_RUN_ATTEMPT) : 1;
+  const targetRun = resolveWorkflowRunTarget(
+    {
+      owner: context2.repo.owner,
+      repo: context2.repo.repo,
+      runId: context2.runId,
+      runAttempt
+    },
+    {
+      eventName: context2.eventName,
+      action: context2.payload.action,
+      workflowRun: {
+        id: context2.payload.workflow_run?.id,
+        runAttempt: context2.payload.workflow_run?.run_attempt
+      }
+    }
+  );
   const workflowRun = await client.fetchWorkflowRun(
-    context2.repo.owner,
-    context2.repo.repo,
-    context2.runId,
-    runAttempt
+    targetRun.owner,
+    targetRun.repo,
+    targetRun.runId,
+    targetRun.runAttempt
   );
   debug(JSON.stringify(workflowRun, null, 2));
   info("Fetch workflow_job...");

--- a/src/post.ts
+++ b/src/post.ts
@@ -13,6 +13,7 @@ import { createMermaid } from "./workflow_gantt.ts";
 import { expandCompositeSteps } from "./composite.ts";
 import { Github } from "./github.ts";
 import { expandParallelSteps } from "./parallel.ts";
+import { resolveWorkflowRunTarget } from "./workflow_run.ts";
 
 const PARALLEL_FALLBACK_SUMMARY =
   "Parallel steps could not be expanded for one or more jobs. Those jobs use the standard timeline layout.\n\n";
@@ -35,11 +36,27 @@ const main = async () => {
   const runAttempt = process.env.GITHUB_RUN_ATTEMPT
     ? Number(process.env.GITHUB_RUN_ATTEMPT)
     : 1;
+  const targetRun = resolveWorkflowRunTarget(
+    {
+      owner: github.context.repo.owner,
+      repo: github.context.repo.repo,
+      runId: github.context.runId,
+      runAttempt,
+    },
+    {
+      eventName: github.context.eventName,
+      action: github.context.payload.action,
+      workflowRun: {
+        id: github.context.payload.workflow_run?.id,
+        runAttempt: github.context.payload.workflow_run?.run_attempt,
+      },
+    },
+  );
   const workflowRun = await client.fetchWorkflowRun(
-    github.context.repo.owner,
-    github.context.repo.repo,
-    github.context.runId,
-    runAttempt,
+    targetRun.owner,
+    targetRun.repo,
+    targetRun.runId,
+    targetRun.runAttempt,
   );
   debug(JSON.stringify(workflowRun, null, 2));
   info("Fetch workflow_job...");

--- a/src/workflow_run.ts
+++ b/src/workflow_run.ts
@@ -1,0 +1,49 @@
+export type WorkflowRunTarget = {
+  owner: string;
+  repo: string;
+  runId: number;
+  runAttempt: number;
+};
+
+export type WorkflowRunEvent = {
+  eventName: string;
+  action?: string;
+  workflowRun?: {
+    id?: unknown;
+    runAttempt?: unknown;
+  };
+};
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+export function resolveWorkflowRunTarget(
+  currentRun: WorkflowRunTarget,
+  event: WorkflowRunEvent,
+): WorkflowRunTarget {
+  if (event.eventName !== "workflow_run" || event.action !== "completed") {
+    return currentRun;
+  }
+
+  const runId = event.workflowRun?.id;
+  if (!isPositiveInteger(runId)) {
+    throw new Error(
+      "workflow_run.completed payload is missing a valid workflow run id",
+    );
+  }
+
+  const runAttempt = event.workflowRun?.runAttempt ?? 1;
+  if (!isPositiveInteger(runAttempt)) {
+    throw new Error(
+      "workflow_run.completed payload has an invalid workflow run attempt",
+    );
+  }
+
+  return {
+    owner: currentRun.owner,
+    repo: currentRun.repo,
+    runId,
+    runAttempt,
+  };
+}

--- a/tests/workflow_run.test.ts
+++ b/tests/workflow_run.test.ts
@@ -1,0 +1,92 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { resolveWorkflowRunTarget } from "../src/workflow_run.ts";
+
+const currentRun = {
+  owner: "Kesin11",
+  repo: "actions-timeline",
+  runId: 1000000000,
+  runAttempt: 2,
+};
+
+Deno.test(resolveWorkflowRunTarget.name, async (t) => {
+  await t.step("uses the current run for other events", () => {
+    const actual = resolveWorkflowRunTarget(currentRun, {
+      eventName: "push",
+    });
+    assertEquals(actual, currentRun);
+  });
+
+  await t.step("uses the completed triggering run", () => {
+    const actual = resolveWorkflowRunTarget(currentRun, {
+      eventName: "workflow_run",
+      action: "completed",
+      workflowRun: {
+        id: 2000000000,
+        runAttempt: 3,
+      },
+    });
+    const expected = {
+      owner: "Kesin11",
+      repo: "actions-timeline",
+      runId: 2000000000,
+      runAttempt: 3,
+    };
+    assertEquals(actual, expected);
+  });
+
+  await t.step("defaults the triggering run attempt", () => {
+    const actual = resolveWorkflowRunTarget(currentRun, {
+      eventName: "workflow_run",
+      action: "completed",
+      workflowRun: {
+        id: 2000000000,
+      },
+    });
+    const expected = {
+      owner: "Kesin11",
+      repo: "actions-timeline",
+      runId: 2000000000,
+      runAttempt: 1,
+    };
+    assertEquals(actual, expected);
+  });
+
+  await t.step("uses the current run for other workflow run actions", () => {
+    const actual = resolveWorkflowRunTarget(currentRun, {
+      eventName: "workflow_run",
+      action: "requested",
+      workflowRun: {
+        id: 2000000000,
+      },
+    });
+    assertEquals(actual, currentRun);
+  });
+
+  await t.step("rejects a missing triggering run id", () => {
+    assertThrows(
+      () =>
+        resolveWorkflowRunTarget(currentRun, {
+          eventName: "workflow_run",
+          action: "completed",
+        }),
+      Error,
+      "missing a valid workflow run id",
+    );
+  });
+
+  await t.step("rejects an invalid triggering run attempt", () => {
+    assertThrows(
+      () =>
+        resolveWorkflowRunTarget(currentRun, {
+          eventName: "workflow_run",
+          action: "completed",
+          workflowRun: {
+            id: 2000000000,
+            runAttempt: 0,
+          },
+        }),
+      Error,
+      "invalid workflow run attempt",
+    );
+  });
+});


### PR DESCRIPTION
Uses the triggering workflow run ID and attempt for `workflow_run.completed` events while keeping current-run behavior for other events. Adds regression coverage and updates the bundled action.

Tests: `deno fmt --check src/post.ts src/workflow_run.ts tests/workflow_run.test.ts`, `deno lint`, `deno check src/post.ts`, `deno test --allow-env`, and `deno task bundle`.

Closes #157
